### PR TITLE
Issue #5 - Added error styling for inputs

### DIFF
--- a/src/assets/styles/settings/_variables.scss
+++ b/src/assets/styles/settings/_variables.scss
@@ -100,6 +100,8 @@ $input-border-width:          1px;
 $input-border-color:          $color-gray-60;
 $input-border-radius:         $border-radius-base;
 
+$input-border-color-error:    $color-destructive;
+
 $input-focus-border-color:    $color-ao-primary;
 $input-focus-shadow:          0 0 0 1px transparentize($color-ao-primary, 0.5);
 

--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -4,6 +4,7 @@
     <div :class="{ 'ao-input-group': hasInputGroup }">
       <input
         class="ao-form-control"
+        :class="{'ao-form-control--has-error': hasError }"
         :type="type"
         @input="updateValue($event.target.value)"
         :placeholder="placeholder"
@@ -123,6 +124,11 @@ export default {
     step: {
       type: Number,
       default: 1
+    },
+
+    hasError: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -191,6 +197,10 @@ label {
   &[disabled] {
     cursor: not-allowed;
   }
+
+  &--has-error {
+    border-color: $input-border-color-error;
+  }
 }
 
 .ao-input-group {
@@ -231,4 +241,5 @@ label {
     }
   }
 }
+
 </style>


### PR DESCRIPTION
Added error styling for inputs in the AoInput.

# QA

1. hasError prop is a boolean and is false by default, send through true to show error highlighting