### PR TITLE
disable eslint  in blaze-plugin.js for App.vue

### DIFF
--- a/src/blaze-plugin.js
+++ b/src/blaze-plugin.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line
 import App from './App.vue'
 import AoAlert from './components/AoAlert.vue'
 import AoButton from './components/AoButton.vue'


### PR DESCRIPTION
it needs to be an import and does not get used for anything other than importing styles.
Alternatives are welcome but this is the current way to import styles in the blaze plugin

this just removes the lint error (as it is not an error)