### PR TITLE
Add search to be a valid input type

### DIFF
--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -41,7 +41,7 @@ export default {
       default: 'text',
       validator: function (inputType) {
         // Used to determine if the input type prop used is found in this array and therefore valid
-        return ['text', 'number', 'tel', 'email', 'password', 'date'].indexOf(inputType) !== -1
+        return ['text', 'number', 'email', 'password', 'date', 'search'].indexOf(inputType) !== -1
       }
     },
 

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -100,7 +100,10 @@
 
         <ao-text-area v-model="description" />
         <p>Description: {{ description }}</p>
-
+        <ao-input
+          :label="'Search Example (does not search anything)'"
+          :placeholder="'Search'"
+          :type="'search'"/>
         <ao-button
           primary
           :type="'submit'"


### PR DESCRIPTION
Search are valid Input types, this just removes the Vue warning in console.

Also removed 'tel' cause only safari supports it

# QA 

open the demo page and check if the search input is there
confirm that there is no console warning either