### PR TITLE
remove broken uneeded badge component test

### DIFF
--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -100,7 +100,7 @@
           :default="nicePets"
           :has-error="true"
         />
-        <p>I like this pet: {{ nicePets }} <ao-badge/></p>
+        <p>I like this pet: {{ nicePets }} <ao-badge text="Badge"/></p>
 
         <ao-text-area v-model="description" />
         <p>Description: {{ description }}</p>

--- a/tests/unit/AoBadge.spec.js
+++ b/tests/unit/AoBadge.spec.js
@@ -5,7 +5,6 @@ describe('Badge', () => {
   it('defines text prop to be valid and to default to null', () => {
     const text = Badge.props.text
     expect(text.type.name).to.equal('String')
-    expect(typeof text.default).to.equal('string')
     expect(text.default).to.equal(null)
     expect(text.required).to.equal(true)
   })


### PR DESCRIPTION
accidentally merged a bad test,

its not needed so I just removed it

also added text to the badge in Demo.vue

# QA 
1. Go to Demo page (by running `yarn serve`) and make sure the badge on screen has text
2. Run tests by running `yarn test` and make sure they all pass!
