### PR TITLE
ao-callout

### DIFF
--- a/src/assets/styles/settings/_variables.scss
+++ b/src/assets/styles/settings/_variables.scss
@@ -14,14 +14,30 @@ $color-dark:                  #292F3B;
 
 $color-white:                 #fff;
 $color-green:                 #17a66c;
+$color-green-light:           #def7ed;
+$color-green-dark:            #08774a;
 $color-blue:                  #00b0e4;
+$color-blue-light:            #e7f8fd;
+$color-blue-dark:             #007598;
 $color-yellow:                #f9c228;
+$color-yellow-light:          #fff8e4;
+$color-yellow-dark:           #906a01;
 $color-red:                   #d93240;
+$color-red-light:             #ffe1e3;
+$color-red-dark:              #a11e29;
 
 $color-success:               $color-green;
+$color-success-light:         $color-green-light;
+$color-success-dark:          $color-green-dark;
 $color-info:                  $color-blue;
+$color-info-light:            $color-blue-light;
+$color-info-dark:             $color-blue-dark;
 $color-caution:               $color-yellow;
+$color-caution-light:         $color-yellow-light;
+$color-caution-dark:          $color-yellow-dark;
 $color-destructive:           $color-red;
+$color-destructive-light:     $color-red-light;
+$color-destructive-dark:      $color-red-dark;
 
 // Ample Shades of Gray
 $color-gray-10:               #474a4c;

--- a/src/blaze-plugin.js
+++ b/src/blaze-plugin.js
@@ -3,6 +3,7 @@ import AoAlert from './components/AoAlert.vue'
 import AoBadge from './components/AoBadge.vue'
 import AoBreadcrumbs from './components/AoBreadcrumbs.vue'
 import AoButton from './components/AoButton.vue'
+import AoCallout from './components/AoCallout.vue'
 import AoCard from './components/AoCard.vue'
 import AoCheckbox from './components/AoCheckbox.vue'
 import AoDropdown from './components/AoDropdown.vue'
@@ -28,6 +29,7 @@ const Blaze = {
     Vue.component('AoBadge', AoBadge)
     Vue.component('AoBreadcrumbs', AoBreadcrumbs)
     Vue.component('AoButton', AoButton)
+    Vue.component('AoCallout', AoCallout)
     Vue.component('AoCard', AoCard)
     Vue.component('AoCheckbox', AoCheckbox)
     Vue.component('AoDropdown', AoDropdown)

--- a/src/components/AoCallout.vue
+++ b/src/components/AoCallout.vue
@@ -1,0 +1,74 @@
+<template>
+  <div :class="[computedClasses, 'ao-callout']">
+    <slot/>
+  </div>
+</template>
+
+<script>
+import { filterClasses } from './utils/component_utilities.js'
+export default {
+  props: {
+    info: {
+      type: Boolean,
+      default: false
+    },
+    success: {
+      type: Boolean,
+      default: false
+    },
+    caution: {
+      type: Boolean,
+      default: false
+    },
+    destructive: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    computedClasses () {
+      const computedClasses = {
+        'ao-callout--info': this.info,
+        'ao-callout--success': this.success,
+        'ao-callout--caution': this.caution,
+        'ao-callout--destructive': this.destructive
+      }
+      return filterClasses(computedClasses)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+  .ao-callout {
+    padding: $spacer;
+    margin-bottom: $spacer;
+    background: $color-gray-90;
+
+    *:last-child {
+      margin-bottom: 0;
+    }
+
+    &--info {
+      background: $color-info-light;
+      color: $color-info-dark;
+    }
+
+    &--success {
+      background: $color-success-light;
+      color: $color-success-dark;
+    }
+
+    &--caution {
+      background: $color-caution-light;
+      color: $color-caution-dark;
+    }
+
+    &--destructive {
+      background: $color-destructive-light;
+      color: $color-destructive-dark;
+    }
+  }
+
+</style>

--- a/src/components/AoCard.vue
+++ b/src/components/AoCard.vue
@@ -8,6 +8,9 @@
         <slot name="card-header-toolbar"/>
       </div>
     </div>
+    <div class="ao-card__callout">
+      <slot name="card-callout"/>
+    </div>
     <div class="ao-card__body">
       <slot/>
     </div>
@@ -68,6 +71,10 @@ export default {
       margin-left: $spacer-sm;
       margin-bottom: 0 !important;
     }
+  }
+
+  &__callout /deep/ .ao-callout {
+    margin-bottom: 0;
   }
 }
 </style>

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -225,6 +225,29 @@
           </tr>
         </ao-table>
       </ao-card>
+      <ao-card title="Callouts">
+        <ao-callout
+          slot="cardCallout"
+          caution>
+          I am a card callout! I am passed into the cardCallout slot and am flush with the card.
+        </ao-callout>
+        <ao-callout>
+          <p>This is default callout</p>
+        </ao-callout>
+        <ao-callout info>
+          <p>This is an info callout</p>
+          <p>The last element in any callout is given a margin-bottom of 0.</p>
+        </ao-callout>
+        <ao-callout success>
+          <p>This is a success callout</p>
+        </ao-callout>
+      </ao-card>
+      <ao-callout caution>
+        <p>This is a caution callout</p>
+      </ao-callout>
+      <ao-callout destructive>
+        <p>This is a destructive callout</p>
+      </ao-callout>
 
       <ao-modal
         v-if="showModal"

--- a/tests/unit/AoCallout.spec.js
+++ b/tests/unit/AoCallout.spec.js
@@ -1,0 +1,45 @@
+import { mount } from '@vue/test-utils'
+import Callout from '@/components/AoCallout.vue'
+
+describe('Callout', () => {
+  it('create', () => {
+    const callout = mount(Callout)
+    expect(callout.classes()).toContain('ao-callout')
+  })
+
+  it('info', () => {
+    const callout = mount(Callout, {
+      propsData: {
+        info: true
+      }
+    })
+    expect(callout.classes()).toContain('ao-callout--info')
+  })
+
+  it('success', () => {
+    const callout = mount(Callout, {
+      propsData: {
+        success: true
+      }
+    })
+    expect(callout.classes()).toContain('ao-callout--success')
+  })
+
+  it('caution', () => {
+    const callout = mount(Callout, {
+      propsData: {
+        caution: true
+      }
+    })
+    expect(callout.classes()).toContain('ao-callout--caution')
+  })
+
+  it('destructive', () => {
+    const callout = mount(Callout, {
+      propsData: {
+        destructive: true
+      }
+    })
+    expect(callout.classes()).toContain('ao-callout--destructive')
+  })
+})


### PR DESCRIPTION
re. Issue https://github.com/AmpleOrganics/Blaze.vue/issues/79

Created a callout which can be coloured contextually by passing in `info`, `success`, `caution`, or `destructive` as props.

Additionally, there is a new slot underneath the card header that can accommodate a flush callout.