### PR TITLE
Add a min-width to inputs

### DIFF
--- a/src/assets/styles/mixins/shared-input-styles.scss
+++ b/src/assets/styles/mixins/shared-input-styles.scss
@@ -4,6 +4,7 @@
   .ao-form-control {
     display: block;
     width: 100%;
+    min-width: 60px;
     max-width: 100%;
     height: $input-height-base;
     font-family: $font-family-primary;


### PR DESCRIPTION
Inputs (and selects) are basically useless if they get too small, which can happen if they are on a table and the table gets all squished up because of a small container or screen. This will be a kind of safety net. This issue came to light when building tables in ao-wholesale.