### PR TITLE
New button styles, enhancements, demo page additions

### DIFF
--- a/src/assets/styles/global/_elements.scss
+++ b/src/assets/styles/global/_elements.scss
@@ -30,7 +30,13 @@ small {
 }
 
 a {
-  color: $color-primary;
+  color: $font-color-link;
+  text-decoration: none;
+
+  &:hover {
+    color: $font-color-link-hover;
+    text-decoration: underline;
+  }
 }
 
 p {

--- a/src/assets/styles/settings/_variables.scss
+++ b/src/assets/styles/settings/_variables.scss
@@ -80,6 +80,9 @@ $font-color-base:             $color-gray-10;
 $font-color-secondary:        $color-gray-30;
 $font-color-error:            $color-destructive;
 
+$font-color-link:             $color-primary;
+$font-color-link-hover:       $color-primary-dark;
+
 $line-height-base:            1.4;
 
 //

--- a/src/components/AoButton.vue
+++ b/src/components/AoButton.vue
@@ -62,6 +62,16 @@ export default {
       default: false
     },
 
+    link: {
+      type: Boolean,
+      default: false
+    },
+
+    textOnly: {
+      type: Boolean,
+      default: false
+    },
+
     disabled: {
       type: Boolean,
       default: false
@@ -84,6 +94,8 @@ export default {
         'ao-button--naked': this.naked,
         'ao-button--small': this.small,
         'ao-button--large': this.large,
+        'ao-button--link': this.link,
+        'ao-button--text-only': this.textOnly,
         'ao-button--jumbo': this.jumbo
       }
       return filterClasses(activeClasses)
@@ -107,6 +119,22 @@ export default {
      color: darken($color, $darken-delta);
    }
  }
+}
+
+/*
+*  `naked`, `link`, and `text-only` share a base set of styles that remove
+*   borders, backgrounds, and box-shadows
+*/
+@mixin naked-shared {
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: 0 0 0 rgba(0,0,0,0);
+}
+
+@mixin naked-hover-shared {
+  border-color: transparent;
+  background-color: transparent;
+  box-shadow: 0 0 0 rgba(0,0,0,0);
 }
 
 .ao-button {
@@ -199,5 +227,39 @@ export default {
    height: 80px;
    margin-left: 0;
  }
+
+   /*
+    * `link`: use when you want the button text to seem like link text.
+    * Note: It will still have the sizing and spacing of a button, which is
+    * only desireable if it should be lining up with other buttons. If it
+    * is supposed to look like a normal text link, add `textOnly` prop as well.
+  */
+  &--link {
+    @include naked-shared;
+    color: $font-color-link;
+    font-weight: normal;
+
+    &:hover, :active {
+      @include naked-hover-shared;
+      color: $font-color-link-hover;
+      text-decoration: underline;
+    }
+  }
+
+  /*
+  * `textOnly`: Kills padding and min-height so it is identical to normal text
+  * Good to use with `link` when you want a button to look just like a normal link.
+  */
+  &--text-only {
+    @include naked-shared;
+    font-weight: normal;
+    padding: 0;
+    min-height: auto;
+    vertical-align: baseline;
+
+    &:hover, :active {
+      @include naked-hover-shared;
+    }
+  }
 }
 </style>

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -176,7 +176,12 @@
           :name="'file1'"
           @change="updateFile($event)"/>
 
-        <p>Filename: {{ file }}</p>
+        <ao-input
+          :type="'number'"
+          :label="'Age'"
+          v-model="age"
+          :step="5"/>
+        <p>My age: {{ age }}</p>
 
         <label>Favorite Programming Languages?</label>
         <ao-checkbox
@@ -332,13 +337,11 @@
 
           <ao-select
             v-model="nicePets"
-            :label="'Pets'"
-            :placeholder="'Select One'"
-            :invalid="true">
-            <option value="dog">Dog</option>
-            <option value="cat">Cat</option>
-            <option value="elephant">Elephant</option>
-          </ao-select>
+            :options="pets"
+            :label="'Nice Pets'"
+            :default="nicePets"
+            :has-error="true"
+          />
           <p>I like this pet: {{ nicePets }} <ao-badge text="Badge"/></p>
 
           <ao-text-area v-model="description" />
@@ -411,7 +414,36 @@
       <ao-callout destructive>
         <p>This is a destructive callout</p>
       </ao-callout>
-
+      <ao-card title="Buttons">
+        <ao-button>Default</ao-button>
+        <ao-button primary>Primary</ao-button>
+        <ao-button caution>Caution</ao-button>
+        <ao-button destructive>Destructive</ao-button>
+        <ao-button subtle>Subtle</ao-button>
+        <hr>
+        <ao-button nano>Nano</ao-button>
+        <ao-button small>Small</ao-button>
+        <ao-button>Normal</ao-button>
+        <ao-button large>Large</ao-button>
+        <hr>
+        <ao-button jumbo>Jumbo</ao-button>
+        <hr>
+        <p>
+          <ao-button :naked="true">Naked</ao-button>
+          <ao-button link>Link</ao-button>
+          <ao-button text-only>Text Only</ao-button>
+          <span>, and how about some </span>
+          <ao-button
+            text-only
+            link>link AND text only??</ao-button>
+        </p>
+      </ao-card>
+      <ao-card title="Text">
+        <p>Normal Text</p>
+        <p><a href="#">Link</a></p>
+        <p><ao-text-style error>Error</ao-text-style></p>
+        <p><ao-text-style small>Small</ao-text-style></p>
+      </ao-card>
       <ao-modal
         v-if="showModal"
         :header-text="'I am the modal title'"

--- a/tests/unit/AoButton.spec.js
+++ b/tests/unit/AoButton.spec.js
@@ -78,4 +78,22 @@ describe('Button', () => {
     })
     expect(button.classes()).toContain('ao-button--jumbo')
   })
+
+  it('link', () => {
+    const button = mount(Button, {
+      propsData: {
+        link: true
+      }
+    })
+    expect(button.classes()).toContain('ao-button--link')
+  })
+
+  it('textOnly', () => {
+    const button = mount(Button, {
+      propsData: {
+        textOnly: true
+      }
+    })
+    expect(button.classes()).toContain('ao-button--text-only')
+  })
 })


### PR DESCRIPTION
- Fixed button min-height issue (https://github.com/AmpleOrganics/Blaze.vue/issues/73, https://github.com/AmpleOrganics/Blaze.vue/pull/161)
- Changed links to not be underlined until hover (https://github.com/AmpleOrganics/Blaze.vue/issues/59)
- Changed variables for link styles so they are more easily used/changed abstractly
- Added a bunch of buttons to demonstrate different styles as a sort of pseudo documentation
- Some reorganization of styles in aoButton because it's getting sprawling and I wanted to add comments for a bunch of those things.
- Added new button styles and tests (https://github.com/AmpleOrganics/Blaze.vue/issues/72)