### PR TITLE
Create a heading component

### DIFF
--- a/src/blaze-plugin.js
+++ b/src/blaze-plugin.js
@@ -6,7 +6,9 @@ import AoButton from './components/AoButton.vue'
 import AoCard from './components/AoCard.vue'
 import AoCheckbox from './components/AoCheckbox.vue'
 import AoDropdown from './components/AoDropdown.vue'
+import AoFileUpload from './components/AoFileUpload.vue'
 import AoHeaderToolbar from './components/AoHeaderToolbar.vue'
+import AoHeading from './components/AoHeading.vue'
 import AoInfoPair from './components/AoInfoPair.vue'
 import AoInput from './components/AoInput.vue'
 import AoModal from './components/AoModal.vue'
@@ -19,7 +21,6 @@ import AoSpinner from './components/AoSpinner.vue'
 import AoTable from './components/AoTable.vue'
 import AoTextArea from './components/AoTextArea.vue'
 import AoTextStyle from './components/AoTextStyle.vue'
-import AoFileUpload from './components/AoFileUpload.vue'
 import ClickOutside from './directives/click-outside.js'
 
 const Blaze = {
@@ -31,7 +32,9 @@ const Blaze = {
     Vue.component('AoCard', AoCard)
     Vue.component('AoCheckbox', AoCheckbox)
     Vue.component('AoDropdown', AoDropdown)
+    Vue.component('AoFileUpload', AoFileUpload)
     Vue.component('AoHeaderToolbar', AoHeaderToolbar)
+    Vue.component('AoHeading', AoHeading)
     Vue.component('AoInfoPair', AoInfoPair)
     Vue.component('AoInput', AoInput)
     Vue.component('AoModal', AoModal)
@@ -44,7 +47,6 @@ const Blaze = {
     Vue.component('AoTable', AoTable)
     Vue.component('AoTextArea', AoTextArea)
     Vue.component('AoTextStyle', AoTextStyle)
-    Vue.component('AoFileUpload', AoFileUpload)
     Vue.directive('ClickOutside', ClickOutside)
   }
 }

--- a/src/components/AoHeading.vue
+++ b/src/components/AoHeading.vue
@@ -1,0 +1,42 @@
+<template>
+  <h3
+    :class="[computedClasses]">
+    {{ text }}
+  </h3>
+</template>
+
+<script>
+import { filterClasses } from './utils/component_utilities.js'
+export default {
+  props: {
+    text: {
+      type: String,
+      default: null
+    },
+
+    cardSectionHeading: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    computedClasses () {
+      const computedClasses = {
+        'ao-heading--card-section-heading': this.cardSectionHeading
+      }
+      return filterClasses(computedClasses)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+  .ao-heading--card-section-heading {
+    font-size: $font-size-sm;
+    text-transform: uppercase;
+    color: $color-gray-30;
+    font-weight: $font-weight-bold;
+    margin-bottom: $spacer-lg;
+  }
+</style>

--- a/src/components/AoModal.vue
+++ b/src/components/AoModal.vue
@@ -14,6 +14,10 @@
             <div :class="computedHeaderClass">
               <h2>{{ headerText }}</h2>
             </div>
+            <div
+              class="ao-modal__toolbar">
+              <slot name="modal-toolbar"/>
+            </div>
             <div class="ao-modal__body">
               <slot name="modal-body"/>
             </div>
@@ -131,6 +135,18 @@ export default {
     background-clip: padding-box;
     border-radius: $border-radius-base;
     box-shadow: $shadow-dramatic;
+  }
+
+  &__toolbar {
+    padding: $spacer;
+    display: flex;
+    justify-content: flex-end;
+    border-bottom: 1px solid $ui-border-color-base;
+
+    & > /deep/ * {
+      padding-left: $spacer;
+      margin-bottom: 0;
+    }
   }
 
   &__body {

--- a/src/components/AoPaginate.vue
+++ b/src/components/AoPaginate.vue
@@ -64,8 +64,7 @@ export default {
 <style lang='scss' scoped>
 .ao-pagination {
   display: flex;
-  border: 1px solid $input-border-color;
-  border-radius: $border-radius-base;
+  width: 88px;
 
   &__button {
     height: $input-height-base;
@@ -74,16 +73,28 @@ export default {
     justify-content: center;
     align-items: center;
     color: $color-gray-20;
+    border: 1px solid $input-border-color;
+    background: $color-white;
+    z-index: $zindex-base;
+    user-select: none;
 
     &[disabled] {
       cursor: not-allowed !important;
       opacity: 0.65;
       filter: alpha(opacity=65);
       box-shadow: none;
+      color: $color-gray-50;
+      background: $color-white !important;
+      z-index: $zindex-base - 1;
+    }
+
+    &:first-child {
+      border-radius: $border-radius-base 0 0 $border-radius-base;
     }
 
     &:last-child {
-      border-left: 1px solid $input-border-color;
+      border-radius: 0 $border-radius-base $border-radius-base 0;
+      border-left: 0;
     }
 
     &:hover {

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -47,6 +47,9 @@
 
       <ao-card :title="'Title of Card'">
         <ao-breadcrumbs :paths="paths"/>
+        <ao-heading
+          card-section-heading
+          text="Form Examples"/>
         <p>
           <ao-text-style
             error
@@ -300,7 +303,7 @@
       <ao-card :title="'Hi I am a Table!'">
         <ao-paginate
           slot="card-header-toolbar"
-          :total-pages="3"
+          :total-pages="userInfo.total_pages"
           @paginate="paginate"/>
         <ao-table
           :headers="columnHeaders"
@@ -328,6 +331,13 @@
         :size="'md'"
         :header-text="'I am the modal title'"
         @modalClose="toggleModal">
+        <ao-input
+          slot="modal-toolbar"
+          :show-label="false"/>
+        <ao-paginate
+          slot="modal-toolbar"
+          :total-pages="3"
+          @paginate="paginate"/>
         <div slot="modal-body">
           <p>I am content</p>
         </div>

--- a/tests/unit/AoHeading.spec.js
+++ b/tests/unit/AoHeading.spec.js
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils'
+import Heading from '@/components/AoHeading.vue'
+
+describe('Heading', () => {
+  it('create', () => {
+    const heading = mount(Heading, {
+      propsData: {
+        text: 'heading'
+      }
+    })
+    expect(heading.text()).toBe('heading')
+  })
+
+  it('create', () => {
+    const cardSectionHeadingClass = 'ao-heading--card-section-heading'
+
+    const heading = mount(Heading, {
+      propsData: {
+        text: 'heading'
+      }
+    })
+    expect(heading.classes()).not.toContain(cardSectionHeadingClass)
+
+    heading.setProps({ cardSectionHeading: true })
+    expect(heading.classes()).toContain(cardSectionHeadingClass)
+  })
+})


### PR DESCRIPTION
Re. issue https://github.com/AmpleOrganics/Blaze.vue/issues/62

Currently all this is is a single heading text style, to be used as a heading for sections within cards. As we go along I imagine we will build this out to include other heading styles too. Who knows!