### PR TITLE
Keep table data cell padding consistent

### DIFF
--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -108,7 +108,7 @@ export default {
   }
 
   & > tbody /deep/ tr > td {
-    padding: .5rem;
+    padding: 8px;
     vertical-align: middle;
     border-top: 1px solid $color-gray-60;
   }


### PR DESCRIPTION
# Description
The td padding of 0.5rem was not translating well in Webapp. Update the padding to 8px to remove dependency on the parent size and keep cell padding consistent across apps.

Logged in JIRA: https://ampleorganics.atlassian.net/browse/AO-2417
Addresses issue https://github.com/AmpleOrganics/Blaze.vue/issues/109
