### PR TITLE
Docs button

### DIFF
--- a/docs/.vuepress/_variables.scss
+++ b/docs/.vuepress/_variables.scss
@@ -1,0 +1,144 @@
+// Variables
+
+// Variables should follow the `$component-state-property-size` formula for
+// consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
+
+
+//
+// Color system
+//
+
+$color-primary:            #00a38b;
+$color-primary-dark:       darken($color-primary, 5);
+$color-dark:               #292F3B;
+
+$color-white:                 #fff;
+$color-green:                 #17a66c;
+$color-blue:                  #00b0e4;
+$color-yellow:                #f9c228;
+$color-red:                   #d93240;
+
+$color-success:               $color-green;
+$color-info:                  $color-blue;
+$color-caution:               $color-yellow;
+$color-destructive:           $color-red;
+
+// Ample Shades of Gray
+$color-gray-10:               #474a4c;
+$color-gray-20:               #585d60;
+$color-gray-30:               #818a91;
+$color-gray-50:               #ccc;
+$color-gray-60:               #dcdedf;
+$color-gray-80:               #ebecef;
+$color-gray-90:               #f7f7f9;
+$color-grey-light:              #ddd;
+
+//
+// Spacing & Sizing
+//
+
+$spacer:                      1rem;
+$spacer-sm:                   .75rem;
+$spacer-xs:                   .5rem;
+$spacer-lg:                   1.5rem;
+$spacer-micro:                .25rem;
+
+//
+// Typography
+//
+
+$font-family-primary:         'Lato', arial, sans-serif;
+
+$font-size-base:              16px; // This becomes 1rem
+$font-size-xs:                12px;
+$font-size-sm:                14px;
+$font-size-lg:                20px;
+$font-size-xl:                28px;
+$font-size-xxl:               34px;
+
+$font-weight-light:           200;
+$font-weight-bold:            700;
+
+$font-color-base:             $color-gray-10;
+$font-color-secondary:        $color-gray-30;
+$font-color-error:            $color-destructive;
+
+$line-height-base:            1.4;
+
+//
+// Layout
+//
+
+$layout-background-color:    $color-gray-90;
+
+$zindex-dropdown:             1000;
+$zindex-sticky:               1020;
+$zindex-fixed:                1030;
+$zindex-alert:                1035;
+$zindex-spinner:              1035;
+$zindex-modal-backdrop:       1040;
+$zindex-modal:                1050;
+$zindex-tooltip:              1070;
+$zindex-popover:              1060;
+
+//
+// General UI Styles
+//
+
+$ui-border-color-base:        $color-gray-60;
+
+$border-radius-base:          3px;
+
+$shadow-none:                 0 0 0 rgba(0,0,0,0);
+$shadow:                      0px 1px 20px rgba(0,0,0,0.15);
+$shadow-dramatic:             0px 5px 40px rgba(0,0,0,0.35);
+$shadow-subtle:               0px 2px 3px rgba(0, 0, 0, 0.05);
+
+$shadow-inset:                inset 0 2px 3px rgba(0, 0, 0, 0.05);
+
+$transition-base:             0.2s ease;
+
+//
+// Inputs & Buttons
+//
+
+$input-color:                 $color-gray-20;
+$input-height-base:           2.25rem;
+$input-height-sm:             2rem;
+$input-height-lg:             2.5rem;
+// ^ This value will help us ensure consistent heights of inputs and buttons
+$input-border-width:          1px;
+$input-border-color:          $color-gray-60;
+$input-border-radius:         $border-radius-base;
+
+$input-border-color-error:    $color-destructive;
+
+$input-focus-border-color:    $color-primary;
+$input-focus-shadow:          0 0 0 1px transparentize($color-primary, 0.5);
+$input-focus-shadow-error:    0 0 1px transparentize($color-destructive, 0.1);
+
+
+$input-label-margin:          0 0 $spacer-xs;
+
+//
+// Tranisition/Animation Mixins
+//
+
+@mixin slide-fade {
+  .slide-fade {
+    &-enter-active,
+    &-leave-active {
+        transition: all $transition-base;
+    }
+
+    &-enter,
+    &-leave-to {
+        transform: translateY(-20px);
+    }
+
+    &-enter,
+    &-leave-to {
+        opacity: 0;
+    }
+  }
+}

--- a/docs/.vuepress/components/AoAlert.vue
+++ b/docs/.vuepress/components/AoAlert.vue
@@ -1,0 +1,116 @@
+<template>
+  <transition name="slide-fade">
+    <div
+      v-if="showAlert"
+      class="ao-alert">
+      <div :class="computedAlertIconClass">
+        <span :class="iconClass"/>
+      </div>
+      <div class="ao-alert__message">
+        <slot/>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script>
+import { filterClasses } from '../../../src/components/utils/component_utilities.js'
+
+export default {
+  props: {
+    showAlert: {
+      type: Boolean,
+      required: true,
+      default: false
+    },
+
+    iconClass: {
+      type: String,
+      default: null
+    },
+
+    destructive: {
+      type: Boolean,
+      default: false
+    },
+
+    caution: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    computedAlertIconClass () {
+      const activeClasses = {
+        'ao-alert__icon': true,
+        'ao-alert__icon--destructive': this.destructive,
+        'ao-alert__icon--caution': this.caution
+      }
+      return filterClasses(activeClasses)
+    }
+  },
+
+  mounted () {
+    this.autoCloseAlert()
+  },
+
+  methods: {
+    autoCloseAlert () {
+      setTimeout(() => {
+        this.$emit('update:showAlert', false)
+      }, 4000)
+    }
+  }
+
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../_variables.scss';
+
+@include slide-fade;
+
+$ao-alert-height: 3.75rem;
+
+.ao-alert {
+  display: flex;
+  background-color: $color-white;
+  width: 75%;
+  box-shadow: $shadow, $shadow-subtle;
+  min-height: $ao-alert-height;
+
+  &__container {
+    position: fixed;
+    display: flex;
+    justify-content: center;
+    z-index: $zindex-alert;
+    width: 100%;
+    top: 0;
+  }
+
+  &__message {
+    padding: $spacer;
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+  }
+
+  &__icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: $ao-alert-height;
+    background-color: $color-success;
+    color: $color-white;
+
+    &--destructive {
+      background-color: $color-destructive;
+    }
+
+    &--caution {
+      background-color: $color-caution;
+    }
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoBadge.vue
+++ b/docs/.vuepress/components/AoBadge.vue
@@ -1,0 +1,77 @@
+<template>
+  <span :class="computedClasses">{{ text }}</span>
+</template>
+
+<script>
+import { filterClasses } from '../../../src/components/utils/component_utilities.js'
+
+export default {
+  props: {
+    text: {
+      type: String,
+      required: true,
+      default: null
+    },
+
+    success: {
+      type: Boolean,
+      default: false
+    },
+
+    info: {
+      type: Boolean,
+      default: false
+    },
+
+    subtle: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    computedClasses () {
+      const classes = {
+        'ao-badge': true,
+        'ao-badge--success': this.success,
+        'ao-badge--info': this.info,
+        'ao-badge--subtle': this.subtle
+      }
+      return filterClasses(classes)
+    }
+  }
+
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-badge {
+  display: inline;
+  padding: 0.3em 0.6em 0.35em;
+  font-size: $font-size-xs;
+  font-weight: $font-weight-bold;
+  line-height: 1;
+  color: $color-white;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: $border-radius-base;
+  text-transform: uppercase;
+  background: $color-primary;
+
+  &--success {
+    background-color: $color-success;
+  }
+
+  &--info {
+    background-color: $color-info;
+  }
+
+  &--subtle {
+    background: $color-gray-80;
+    color: $color-gray-20;
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoButton.vue
+++ b/docs/.vuepress/components/AoButton.vue
@@ -1,0 +1,216 @@
+<template>
+  <button
+    :type="type"
+    :form="formName"
+    :class="computedButtonClass"
+    :disabled="disabled">
+    <slot/>
+  </button>
+</template>
+
+<script>
+import { filterClasses } from '../../../src/components/utils/component_utilities.js'
+
+export default {
+  props: {
+    type: {
+      type: String,
+      required: false,
+      default: 'button',
+      validator: function (buttonType) {
+        return ['button', 'submit'].indexOf(buttonType) !== -1
+      }
+    },
+
+    formName: {
+      type: String,
+      default: null
+    },
+
+    small: {
+      type: Boolean,
+      default: false
+    },
+
+    large: {
+      type: Boolean,
+      default: false
+    },
+
+    primary: {
+      type: Boolean,
+      default: false
+    },
+
+    destructive: {
+      type: Boolean,
+      default: false
+    },
+
+    caution: {
+      type: Boolean,
+      default: false
+    },
+
+    subtle: {
+      type: Boolean,
+      default: false
+    },
+
+    naked: {
+      type: Boolean,
+      default: false
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+
+    jumbo: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    computedButtonClass () {
+      const activeClasses = {
+        'ao-button': true,
+        'ao-button--primary': this.primary,
+        'ao-button--destructive': this.destructive,
+        'ao-button--caution': this.caution,
+        'ao-button--subtle': this.subtle,
+        'ao-button--naked': this.naked,
+        'ao-button--small': this.small,
+        'ao-button--large': this.large,
+        'ao-button--jumbo': this.jumbo
+      }
+      return filterClasses(activeClasses)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-button {
+  display: inline-block;
+  margin-bottom: 0;
+  text-align: center;
+  font-weight: $font-weight-bold;
+  font-family: $font-family-primary;
+  border: $input-border-width solid transparent;
+  padding: $spacer-micro $spacer-sm;
+  font-size: $font-size-base;
+  line-height: $line-height-base;
+  border-radius: $border-radius-base;
+  min-height: $input-height-base;
+  box-shadow: $shadow-subtle;
+
+ /* Default styles, overridden by special classes */
+  background-color: $color-white;
+  border-color: $color-gray-50;
+  color: $font-color-base;
+
+ /* Default hover/active styles, overridden by special classes */
+  &:active {
+    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  }
+
+  &:hover, &:active {
+    background-color: darken($color-white, 3%);
+    border-color: darken($color-gray-50, 3%);
+    color: darken($font-color-base, 3%);
+  }
+
+  & + &:not(.ao-btn--block) {
+    margin-left: $spacer-micro;
+  }
+
+  &[disabled] {
+    cursor: not-allowed;
+    opacity: 0.65;
+    filter: alpha(opacity=65);
+    box-shadow: none;
+  }
+
+  &--primary {
+    background-color: $color-primary;
+    border-color: $color-primary;
+    color: $color-white;
+
+    &:hover, &:active {
+      border-color: darken($color-primary, 3%);
+      background-color: darken($color-primary, 3%);
+      color: $color-white;
+    }
+  }
+
+  &--destructive {
+    background-color: $color-destructive;
+    border: 1px solid $color-destructive;
+    color: $color-white;
+
+    &:hover, &:active {
+      background-color: darken($color-destructive, 5%);
+      border-color: darken($color-destructive, 5%);
+      color: $color-white;
+    }
+  }
+
+  &--caution {
+    background-color: $color-caution;
+    border: 1px solid $color-caution;
+    color: darken($color-caution, 50%);
+    outline:none;
+
+    &:hover, :active {
+      background-color: darken($color-caution, 5%);
+      border-color: darken($color-caution, 5%);
+      color: darken($color-caution, 60%);
+    }
+  }
+
+  &--subtle {
+    background-color: $color-gray-90;
+    border: 1px solid $color-gray-60;
+
+    &:hover, :active {
+      border-color: darken($color-gray-60, 5%);
+      background-color: darken($color-gray-90, 5%);
+    }
+  }
+
+  &--naked {
+    background-color: transparent;
+    border-color: transparent;
+    box-shadow: $shadow-none;
+
+    &:hover, :active {
+      border-color: transparent;
+      background-color: transparent;
+      box-shadow: $shadow-none;
+    }
+  }
+
+  &--small {
+    height: $input-height-sm;
+    font-size: $font-size-xs;
+    padding-left: $spacer-xs;
+    padding-right: $spacer-xs;
+  }
+
+  &--large {
+    height: $input-height-lg;
+    font-size: $font-size-lg;
+  }
+
+  &--jumbo {
+    width: 100%;
+    height: 80px;
+    margin-left: 0;
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoCard.vue
+++ b/docs/.vuepress/components/AoCard.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="ao-card">
+    <div
+      v-if="title"
+      class="ao-card__header">
+      <h2 class="ao-card__title">{{ title }}</h2>
+      <div class="ao-card__toolbar">
+        <slot name="card-header-toolbar"/>
+      </div>
+    </div>
+    <div class="ao-card__body">
+      <slot/>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      default: null
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-card {
+  background-color: $color-white;
+  border: 1px solid $ui-border-color-base;
+  border-radius: $border-radius-base;
+  margin-bottom: $spacer;
+  padding: 0;
+
+  &__body {
+    padding: $spacer;
+  }
+
+  &__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    padding: 15px;
+    border-bottom: 1px solid $ui-border-color-base;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: $font-size-xl;
+    font-weight: $font-weight-light;
+    display: inline-block;
+  }
+
+  &__toolbar {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+
+    & .form-group {
+      display: inline-block;
+      margin-bottom: 0;
+    }
+
+    & > * {
+      margin-left: $spacer-sm;
+      margin-bottom: 0 !important;
+    }
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoCheckbox.vue
+++ b/docs/.vuepress/components/AoCheckbox.vue
@@ -1,0 +1,95 @@
+<template>
+  <!-- not sure how to refector this into just a label and input TODO: Dan help-->
+  <div class="ao-checkbox">
+    <label
+      :disabled="disabled"
+      class="ao-checkbox__label">
+      <input
+        :value="checkboxValue"
+        v-model="checked"
+        :disabled="disabled"
+        type="checkbox"
+        class="ao-checkbox__input"
+        @change="check">
+      <span v-show="showLabel">{{ checkboxLabel }}</span>
+    </label>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    // both this and checkboxValue needed to avoid vue issue
+    value: {
+      type: [Array, Boolean, Number, Object],
+      default: null
+    },
+
+    checkboxValue: {
+      type: [String, Number, Boolean, Object],
+      default: null
+    },
+
+    showLabel: {
+      type: Boolean,
+      default: true
+    },
+
+    checkboxLabel: {
+      type: String,
+      required: true
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  data () {
+    return {
+      checkedModel: false
+    }
+  },
+
+  computed: {
+    // Sets the v-model as the v-model from the parent, updates the v-model in this component
+    checked: {
+      get () {
+        return this.value
+      },
+      set (value) {
+        this.checkedModel = value
+      }
+    }
+  },
+
+  methods: {
+    check (value) {
+      this.$emit('input', this.checkedModel)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+
+.ao-checkbox {
+  position: relative;
+  display: block;
+  margin-bottom: 10px;
+
+  &__label {
+    min-height: 22px;
+    margin-bottom: 0;
+    font-weight: normal;
+    cursor: pointer;
+  }
+
+  &__input {
+    line-height: normal;
+    box-sizing: border-box;
+    padding: 0;
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoFileUpload.vue
+++ b/docs/.vuepress/components/AoFileUpload.vue
@@ -1,0 +1,52 @@
+<template>
+  <label
+    v-show="showLabel"
+    class="ao-form-group">
+    {{ label }}
+    <input
+      :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
+      :name="name"
+      :disabled="disabled"
+      type="file"
+      @change="updateFile($event.target.files)">
+  </label>
+</template>
+
+<script>
+export default {
+  props: {
+    label: {
+      type: String,
+      required: true
+    },
+
+    showLabel: {
+      type: Boolean,
+      default: true
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+
+    invalid: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  methods: {
+    updateFile (value) {
+      this.$emit('change', value[0])
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+
+@import '../shared-input-styles.scss';
+@include shared-input-styles;
+
+</style>

--- a/docs/.vuepress/components/AoInfoPair.vue
+++ b/docs/.vuepress/components/AoInfoPair.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="ao-info-pair">
+    <h4 class="ao-info-pair__label">{{ label }}</h4>
+    <div class="ao-info-pair__value">
+      <slot/>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    label: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-info-pair {
+  margin-bottom: $spacer;
+
+  &__label {
+    margin-bottom: 0;
+    margin-top: 0;
+    font-weight: $font-weight-bold;
+    font-size: $font-size-xs;
+    text-transform: uppercase;
+    color: $color-gray-30;
+  }
+}
+
+</style>

--- a/docs/.vuepress/components/AoInput.vue
+++ b/docs/.vuepress/components/AoInput.vue
@@ -1,0 +1,125 @@
+<template>
+  <div class="ao-form-group">
+    <label
+      v-show="showLabel"
+      :for="name">{{ label }}</label>
+    <div :class="{ 'ao-input-group': hasInputGroup }">
+      <input
+        :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
+        :type="type"
+        :placeholder="placeholder"
+        :name="name"
+        :value="value"
+        :disabled="disabled"
+        :step="step"
+        @input="updateValue($event.target.value)">
+      <span
+        v-if="hasIconAddon"
+        :class="iconClass"
+        class="ao-input-group__addon"
+        v-html="iconHtml"/>
+      <span
+        v-if="hasAddOn"
+        class="ao-input-group__addon">
+        {{ addOn }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    type: {
+      type: String,
+      default: 'text',
+      validator: function (inputType) {
+        // Used to determine if the input type prop used is found in this array and therefore valid
+        return ['text', 'number', 'email', 'password', 'date', 'search'].includes(inputType)
+      }
+    },
+
+    value: {
+      type: [String, Number],
+      default: null
+    },
+
+    label: {
+      type: String,
+      required: true
+    },
+
+    showLabel: {
+      type: Boolean,
+      default: true
+    },
+
+    name: {
+      type: String,
+      default: null
+    },
+
+    placeholder: {
+      type: String,
+      default: null
+    },
+
+    iconHtml: {
+      type: String,
+      default: null
+    },
+
+    iconClass: {
+      type: String,
+      default: null
+    },
+
+    addOn: {
+      type: String,
+      default: null
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+
+    step: {
+      type: Number,
+      default: 1
+    },
+
+    invalid: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    hasInputGroup () {
+      return this.hasIconAddon || this.hasAddOn
+    },
+
+    hasIconAddon () {
+      return this.iconHtml || this.iconClass
+    },
+
+    hasAddOn () {
+      return this.addOn
+    }
+  },
+
+  methods: {
+    updateValue (value) {
+      this.$emit('input', value)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+
+@import '../shared-input-styles.scss';
+@include shared-input-styles;
+
+</style>

--- a/docs/.vuepress/components/AoModal.vue
+++ b/docs/.vuepress/components/AoModal.vue
@@ -1,0 +1,166 @@
+<template>
+  <transition name="slide-fade">
+    <div class="ao-modal-mask">
+      <div
+        ref="modal"
+        class="ao-modal"
+        tabindex="0"
+        @click.self="closeModal"
+        @keyup.esc.stop="closeModal">
+        <div
+          :class="computedModalSize"
+          @click.self="closeModal">
+          <div class="ao-modal__content">
+            <div :class="computedHeaderClass">
+              <h2>{{ headerText }}</h2>
+            </div>
+            <div class="ao-modal__body">
+              <slot name="modal-body"/>
+            </div>
+            <div class="ao-modal__footer">
+              <div class="row">
+                <slot name="modal-footer"/>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script>
+import { filterClasses } from '../../../src/components/utils/component_utilities.js'
+
+export default {
+  props: {
+    // availible sizes include: 'sm', 'md', 'lg' pertaining to small medium large bootstrap classes
+
+    headerText: {
+      type: String,
+      required: true,
+      default: ''
+    },
+
+    size: {
+      type: String,
+      default: 'md'
+    },
+
+    destructive: {
+      type: Boolean,
+      default: false
+    },
+
+    caution: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    computedHeaderClass () {
+      const activeClasses = {
+        'ao-modal__header': true,
+        'ao-modal__header--destructive': this.destructive,
+        'ao-modal__header--caution': this.caution
+      }
+      return filterClasses(activeClasses)
+    },
+
+    computedModalSize () {
+      // computes sizes into scss classes pertaining to size eg. md -> .ao-modal--md
+      return `ao-modal--${this.size}`
+    }
+  },
+
+  mounted () {
+    // this sets focus on the modal so that the onEsc() functions as expected
+    this.$refs.modal.focus()
+  },
+
+  methods: {
+    closeModal () {
+      // This only affects clicking outside the modal and pressing 'esc' key
+      // if you want to close the modal, the parent of the component shoud maniupulate a showModal
+      // variable that is linked to a v-if and :show
+      this.$emit('modalClose')
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+@include slide-fade;
+
+.ao-modal {
+  padding-top: 2em;
+  z-index: 501;
+  height: 100%;
+
+  &:focus {
+    outline: 0;
+  }
+
+  &__header {
+    margin: 0;
+    padding: $spacer;
+    text-align: center;
+    color: $color-white;
+    background-color: $color-primary;
+
+    &--destructive {
+      background-color: $color-destructive;
+    }
+
+    &--caution {
+      background-color: $color-caution;
+    }
+  }
+
+  &__header /deep/ div > h2 {
+    margin: 0;
+    line-height: $line-height-base;
+    font-size: $font-size-lg;
+    font-weight: $font-weight-bold;
+  }
+
+  &__content {
+    background-color: $color-white;
+    background-clip: padding-box;
+    border-radius: $border-radius-base;
+    box-shadow: $shadow-dramatic;
+  }
+
+  &__body {
+    position: relative;
+    padding: $spacer;
+  }
+
+  &__footer {
+    padding: $spacer;
+    text-align: right;
+    border-top: 1px solid $color-gray-60;
+  }
+
+  &--md &__content {
+    max-width: 40%;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.ao-modal-mask {
+  position: fixed;
+  z-index: $zindex-modal-backdrop;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  overflow: auto;
+}
+</style>

--- a/docs/.vuepress/components/AoNavbar.vue
+++ b/docs/.vuepress/components/AoNavbar.vue
@@ -1,0 +1,44 @@
+<template>
+  <nav class="ao-navbar">
+    <ul>
+      <slot/>
+    </ul>
+  </nav>
+</template>
+
+<style lang='scss' scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-navbar {
+  padding-top: $spacer;
+
+  & > ul {
+    padding: 0;
+    list-style-type: none;
+
+    & > li {
+      display: inline;
+      position: relative;
+      cursor: pointer;
+
+      & /deep/ .router-link-exact-active, .router-link-active, .active {
+        color: $color-gray-20;
+        background-color: $color-gray-80;
+      }
+
+      & > * {
+        text-decoration: none;
+        line-height: $line-height-base;
+        border-radius: $border-radius-base;
+        display: inline-flex;
+        align-items: center;
+        color: $color-gray-30;
+        padding: $spacer-micro $spacer-sm;
+        margin-bottom: $spacer/2;
+        height: $input-height-base;
+        text-transform: capitalize;
+      }
+    }
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoPaginate.vue
+++ b/docs/.vuepress/components/AoPaginate.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="ao-pagination">
+    <a
+      :disabled="page === 1"
+      class="ao-pagination__button"
+      @click="changePage('prev')">
+      &laquo;
+    </a>
+    <a
+      :disabled="page === totalPages"
+      class="ao-pagination__button"
+      @click="changePage('next')">
+      &raquo;
+    </a>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    totalPages: {
+      type: Number,
+      default: 1
+    }
+  },
+
+  data () {
+    return {
+      page: 1
+    }
+  },
+
+  computed: {
+    nextConditions () {
+      return (this.totalPages && this.page < this.totalPages) || !this.totalPages
+    }
+  },
+
+  methods: {
+    changePage (direction) {
+      const page = this.page || 1
+
+      if (direction === 'next') {
+        if (this.nextConditions) {
+          this.page += 1
+        }
+      } else if (direction === 'prev') {
+        // set this.page as null if you can't go back at all
+        this.page = this.page <= 1 ? 1 : (this.page - 1)
+      }
+      // if this.page is null then don't do anything at all
+      // handy guard against api calls/more expensive pagination actions
+      if (this.page &&
+          this.page !== page &&
+          (!this.totalPages || this.page <= this.totalPages)
+      ) {
+        this.$emit('paginate', this.page, direction)
+      }
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-pagination {
+  display: flex;
+  border: 1px solid $input-border-color;
+  border-radius: $border-radius-base;
+
+  &__button {
+    height: $input-height-base;
+    width: $input-height-base;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    color: $color-gray-20;
+
+    &[disabled] {
+      cursor: not-allowed !important;
+      opacity: 0.65;
+      filter: alpha(opacity=65);
+      box-shadow: none;
+    }
+
+    &:last-child {
+      border-left: 1px solid $input-border-color;
+    }
+
+    &:hover {
+      background: $color-gray-90;
+      cursor: pointer;
+    }
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoRadio.vue
+++ b/docs/.vuepress/components/AoRadio.vue
@@ -1,0 +1,64 @@
+<template>
+  <label class="ao-checkbox">
+    <input
+      v-model="checked"
+      :value="val"
+      :disabled="disabled"
+      type="radio"
+      @change="toggle">
+    <span>{{ label }}</span>
+  </label>
+</template>
+
+<script>
+export default {
+  props: {
+    // consistant naming and proxy for vue magic
+    value: {
+      type: [String, Number],
+      required: true
+    },
+
+    val: {
+      type: [String, Number],
+      required: true
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+
+    label: {
+      type: String,
+      required: true
+    }
+  },
+
+  computed: {
+    checked: {
+      get () { return this.value },
+      set (val) {
+        this.proxy = val
+        return this.proxy
+      }
+    }
+  },
+
+  methods: {
+    toggle () {
+      this.$emit('input', this.proxy)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-checkbox {
+  &:not(:last-of-type) {
+    margin-right: $spacer-sm;
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoSectionHeader.vue
+++ b/docs/.vuepress/components/AoSectionHeader.vue
@@ -1,0 +1,105 @@
+<template>
+  <!-- rename? -->
+  <div class="ao-section-header">
+    <div class="ao-section-header__title-block">
+      <span
+        v-if="hasIcon"
+        :class="iconClass"
+        class="ao-section-header__icon"
+        v-html="iconHtml"/>
+      <h1 class="ao-section-header__title">{{ title }}</h1>
+      <div class="ao-section-header__toolbar">
+        <slot name="section-header-toolbar"/>
+      </div>
+    </div>
+    <div
+      v-if="subtitle"
+      class="ao-section-header__subtitle">
+      <p>{{ subtitle }}</p>
+    </div>
+    <slot name="section-header-navbar"/>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true
+    },
+
+    subtitle: {
+      type: String,
+      default: null
+    },
+
+    iconHtml: {
+      type: String,
+      default: null
+    },
+
+    iconClass: {
+      type: String,
+      default: null
+    }
+  },
+
+  computed: {
+    hasIcon () {
+      return this.iconHtml || this.iconClass
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-section-header {
+  background-color: $color-white;
+  border: 1px solid $color-gray-60;
+  border-radius: $border-radius-base;
+  padding: $spacer;
+  margin-bottom: $spacer;
+
+  &__title-block {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  &__icon {
+    display: inline-block;
+    line-height: 1.1;
+    font-size: $font-size-xl;
+    color: $color-primary;
+    margin: 0 $spacer-sm 0 0;
+  }
+
+  &__title {
+    display: inline-block;
+    margin: 0;
+    font-size: $font-size-xl;
+    font-weight: $font-weight-light;
+  }
+
+  &__subtitle > p {
+    margin-bottom: 0;
+    font-style: italic;
+    color: $color-gray-30;
+  }
+
+  &__toolbar {
+    margin-left: auto;
+
+    & .form-group {
+      display: inline-block;
+    }
+
+    & * + * {
+      margin-left: $spacer-sm;
+    }
+  }
+}
+</style>

--- a/docs/.vuepress/components/AoSelect.vue
+++ b/docs/.vuepress/components/AoSelect.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="ao-form-group">
+    <label
+      v-show="showLabel"
+      :disabled="disabled">
+      {{ label }}
+    </label>
+    <div>
+      <select
+        v-model="selected"
+        :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
+        :disabled="disabled">
+        <option
+          v-if="placeholder"
+          :value="null"
+          disabled
+          selected>{{ placeholder }}</option>
+        <slot/>
+      </select>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: String,
+      default: null
+    },
+
+    label: {
+      type: String,
+      required: true
+    },
+
+    showLabel: {
+      type: Boolean,
+      default: true
+    },
+
+    invalid: {
+      type: Boolean,
+      default: false
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+
+    placeholder: {
+      type: String,
+      default: null
+    }
+  },
+
+  data () {
+    return {
+      selected: null
+    }
+  },
+  watch: {
+    selected (newValue) {
+      this.$emit('input', newValue)
+    }
+  },
+
+  mounted () {
+    this.selected = this.value
+  }
+
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../shared-input-styles.scss';
+@include shared-input-styles;
+</style>

--- a/docs/.vuepress/components/AoSpinner.vue
+++ b/docs/.vuepress/components/AoSpinner.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="ao-spinner">
+    <div class="ao-spinner__icon"/>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-spinner {
+  pointer-events: none;
+  top: $spacer-lg;
+  z-index: 501;
+  display: block;
+  position: fixed;
+  right: $spacer-lg;
+
+  &__icon {
+    width: 40px;
+    height: 40px;
+    border: solid 4px transparent;
+    border-top-color: $color-primary;
+    border-left-color: $color-primary;
+    border-radius: 50%;
+    animation: progress-spinner 600ms linear infinite;
+  }
+}
+
+@keyframes progress-spinner {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+</style>

--- a/docs/.vuepress/components/AoTable.vue
+++ b/docs/.vuepress/components/AoTable.vue
@@ -1,0 +1,165 @@
+<template>
+  <table
+    :class="[{ 'ao-table--clickable': isClickable }, 'ao-table']">
+    <thead>
+      <tr>
+        <th
+          v-for="columnHeader in headers"
+          :key="columnHeader.field"
+          :class="isSortableClass(columnHeader.sortable)"
+          @click="sortByHeader(columnHeader.field, columnHeader.sortable)">
+          <span class="ao-table__header">{{ columnHeader.title }}<span :class="isChevroned(columnHeader.field, columnHeader.sortable)"/></span>
+        </th>
+      </tr>
+    </thead>
+    <tbody :class=" { clickable: isClickable }">
+      <slot />
+    </tbody>
+  </table>
+</template>
+
+<script>
+export default {
+  props: {
+    headers: {
+      type: Array,
+      default: null
+    },
+
+    isClickable: {
+      type: Boolean,
+      default: false
+    },
+
+    sortBy: {
+      type: String,
+      default: null
+    },
+
+    order: {
+      type: String,
+      default: 'desc',
+      validator: function (order) {
+        return ['asc', 'desc'].includes(order)
+      }
+    }
+  },
+
+  data () {
+    return {
+      lastSelectedHeader: this.sortBy,
+      sortProxy: this.sortBy,
+      orderProxy: this.order
+    }
+  },
+
+  methods: {
+    sortByHeader (header, sortable) {
+      // undefined is used so you do not have to set searchable
+      if (sortable === true || sortable === undefined) {
+        if (header === this.lastSelectedHeader) {
+          this.orderProxy = this.toggleOrder(this.orderProxy)
+        } else {
+          this.lastSelectedHeader = header
+          this.orderProxy = 'desc'
+          this.sortProxy = header
+        }
+        this.$emit('sortTable', this.sortProxy, this.orderProxy)
+      }
+    },
+
+    isSortableClass (sortable) {
+      return sortable === true || sortable === undefined ? 'ao-table__th--sortable' : null
+    },
+
+    isChevroned (name, sortable) {
+      if (name === this.sortProxy && (sortable === true || sortable === undefined)) {
+        return this.orderProxy === 'desc' ? 'glyphicon glyphicon-chevron-down ao-table__sort-icon' : 'glyphicon glyphicon-chevron-up ao-table__sort-icon'
+      }
+    },
+
+    toggleOrder (order) {
+      return order === 'asc' ? 'desc' : 'asc'
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../../../src/assets/styles/settings/_variables.scss';
+
+.ao-table {
+  font-size: $font-size-sm;
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: $spacer;
+  background: transparent;
+  overflow-x: auto;
+  min-height: 0.01%;
+
+  &--clickable {
+    tbody > tr {
+      cursor: pointer;
+    }
+
+    & > tbody > tr:hover {
+      background: $color-gray-80;
+    }
+  }
+
+  & > tbody > tr:nth-of-type(odd) {
+    background-color: $color-gray-90;
+  }
+
+  & > tbody /deep/ tr > td {
+    padding: 0.5rem;
+    vertical-align: middle;
+    border-top: 1px solid $color-gray-60;
+  }
+
+  & th {
+    font-weight: $font-weight-bold;
+    text-align: left;
+  }
+
+  & thead > tr > th {
+    color: $color-gray-10;
+    vertical-align: bottom;
+    border-bottom: 2px solid $color-grey-light;
+    padding: 8px;
+    line-height: 1.4;
+  }
+
+  &__th--sortable > span {
+    cursor: pointer;
+    border-bottom: 1px dotted $color-gray-10;
+  }
+
+  &__sort-icon {
+    margin-left: 0.5rem;
+    font-size: 11px;
+    top: 0;
+  }
+
+  /deep/ &__action-column {
+    text-align: right;
+  }
+
+  /deep/ & tr &__row-button {
+    opacity: 0.25;
+    height: $input-height-sm;
+    font-size: $font-size-xs;
+    padding-left: $spacer-xs;
+    padding-right: $spacer-xs;
+  }
+
+  /deep/ & tr:hover &__row-button {
+    opacity: 1;
+  }
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+</style>

--- a/docs/.vuepress/components/AoTextArea.vue
+++ b/docs/.vuepress/components/AoTextArea.vue
@@ -1,0 +1,94 @@
+<template>
+  <!-- investigate min max length -->
+  <div class="ao-form-group">
+    <label
+      v-show="showLabel"
+      :for="name">{{ label }}</label>
+    <textarea
+      :class="{'ao-form-control--invalid': invalid }"
+      :value="value"
+      :placeholder="placeholder"
+      :name="name"
+      :rows="rows"
+      :maxlength="maxLength"
+      :minlength="minLength"
+      :disabled="disabled"
+      class="ao-form-control"
+      @input="inputEvent($event.target.value)"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: String,
+      default: null
+    },
+
+    label: {
+      type: String,
+      default: null
+    },
+
+    name: {
+      type: String,
+      default: null
+    },
+
+    placeholder: {
+      type: String,
+      default: null
+    },
+
+    maxLength: {
+      type: Number,
+      default: 100000
+    },
+
+    minLength: {
+      type: Number,
+      default: 0
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+
+    rows: {
+      type: Number,
+      default: 5
+    },
+
+    invalid: {
+      type: Boolean,
+      default: false
+    },
+
+    showLabel: {
+      type: Boolean,
+      default: true
+    }
+  },
+
+  methods: {
+    inputEvent (updatedValue) {
+      this.$emit('input', updatedValue)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+@import '../shared-input-styles.scss';
+@include shared-input-styles;
+
+.ao-form-control {
+  height: auto;
+  min-height: $input-height-base;
+  min-width: 100%;
+}
+
+</style>

--- a/docs/.vuepress/components/AoTextStyle.vue
+++ b/docs/.vuepress/components/AoTextStyle.vue
@@ -1,0 +1,44 @@
+<template>
+  <span :class="[computedClasses, 'ao-text']" >
+    <slot/>
+  </span>
+</template>
+
+<script>
+import { filterClasses } from '../../../src/components/utils/component_utilities.js'
+
+export default {
+  props: {
+    error: {
+      type: Boolean,
+      default: false
+    },
+
+    small: {
+      type: Boolean,
+      default: false
+    }
+  },
+
+  computed: {
+    computedClasses () {
+      const computedClasses = {
+        'ao-text--error': this.error,
+        'ao-text--small': this.small
+      }
+      return filterClasses(computedClasses)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+  @import '../_variables.scss';
+  .ao-text--error {
+    color: $font-color-error;
+  }
+
+  .ao-text--small {
+    font-size: $font-size-xs;
+  }
+</style>

--- a/docs/.vuepress/components/Doc/Button.vue
+++ b/docs/.vuepress/components/Doc/Button.vue
@@ -1,0 +1,85 @@
+<template>
+  <div>
+    <div class="component-example">
+      <ao-button
+        :primary="activateProp('primary')"
+        :destructive="activateProp('destructive')"
+        :caution="activateProp('caution')"
+        :subtle="activateProp('subtle')"
+        :naked="activateProp('naked')"
+        :small="activateProp('small')"
+        :large="activateProp('large')"
+        :jumbo="activateProp('jumbo')"
+        :disabled="disabled">
+        {{ buttonText }}
+      </ao-button>
+    </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model="buttonText"
+          :type="'text'"
+          :label="'Button Text'"
+        />
+      </div>
+      <div class="component-controls__group">
+        <ao-select
+          label="Context"
+          v-model="selectedContext">
+          <option v-for="(prop, index) in contextProps" :key="index" :value="prop.value">{{ prop.name }}</option>
+        </ao-select>
+      </div>
+      <div class="component-controls__group">
+        <ao-select
+          label="Size"
+          v-model="selectedSize">
+          <option v-for="(prop, index) in sizeProps" :key="index" :value="prop.value">{{ prop.name }}</option>
+        </ao-select>
+      </div>
+      <div class="component-controls__group">
+        <ao-checkbox
+          v-model="disabled"
+          :checkbox-label="'Disabled'"
+          :checkbox-value="true"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  data() {
+    return {
+      buttonText: 'Text',
+      contextProps: [
+        {name: 'Default', value: null},
+        {name: 'Primary', value: 'primary'},
+        {name: 'Destructive', value: 'destructive'},
+        {name: 'Caution', value: 'caution'},
+        {name: 'Subtle', value: 'subtle'},
+        {name: 'Naked', value: 'naked'}
+      ],
+      selectedContext: null,
+      sizeProps: [
+        {name: 'Default', value: null},
+        {name: 'Small', value: 'small'},
+        {name: 'Large', value: 'large'},
+        {name: 'Jumbo', value: 'jumbo'},
+        ],
+      selectedSize: "default",
+      disabled: false
+    }
+  },
+
+  methods: {
+    activateProp(compare) {
+      return compare === this.selectedContext || compare === this.selectedSize
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,0 +1,52 @@
+const fs = require('fs')
+module.exports = {
+  locales: {
+    '/': {
+      lang: 'en-US',
+      title: 'Blaze',
+      description: 'Component Library created by Ample Organics'
+    }
+  },
+  serviceWorker: true,
+  themeConfig: {
+    repo: 'AmpleOrganics/Blaze.vue',
+    docsDir: 'docs',
+    docsBranch: 'master',
+    editLinks: true,
+    sidebarDepth: 3,
+    locales: {
+      '/': {
+        label: 'English',
+        selectText: 'Languages',
+        lastUpdated: 'Last Updated',
+        editLinkText: 'Edit this page on GitHub',
+        nav: [
+          {
+            text: 'Components',
+            link: '/components/'
+          }
+        ],
+        sidebar: {
+          '/components/':[
+            '/components/',
+            {
+              title: 'Components',
+              collapsable: false,
+              children: [
+                '/components/Button'
+              ]
+            },
+
+          ]
+        }
+      }
+    },
+    css: {
+      loaderOptions: {
+        scss: {
+          data: fs.readFileSync('./docs/.vuepress/_variables.scss', 'utf-8')
+        }
+      }
+    }
+  }
+}

--- a/docs/.vuepress/shared-input-styles.scss
+++ b/docs/.vuepress/shared-input-styles.scss
@@ -1,0 +1,86 @@
+// Mixin for shared input styles
+@import 'variables.scss';
+@mixin shared-input-styles {
+  .ao-form-control {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: $input-height-base;
+    font-family: $font-family-primary;
+    font-size: $font-size-base;
+    line-height: $line-height-base;
+    color: $input-color;
+    background-color: $color-white;
+    background-image: none;
+    border: $input-border-width solid $input-border-color;
+    border-radius: $input-border-radius;
+    padding: $spacer-micro $spacer-sm;
+    transition: border-color $transition-base;
+    &:active:not([disabled]),
+    &:focus {
+      outline: 0;
+      box-shadow: $input-focus-shadow;
+      border-color: $input-focus-border-color;
+    }
+    &[disabled],
+    &[readonly] {
+      background-color: $color-gray-80;
+      border-color: $color-gray-60;
+      opacity: 1;
+    }
+    &[disabled] {
+      cursor: not-allowed;
+    }
+    &--invalid {
+      border-color: $input-border-color-error;
+      &:active:not([disabled]),
+      &:focus {
+        border-color: $input-border-color-error;
+        box-shadow: $input-focus-shadow-error;
+      }
+    }
+  }
+  .ao-input-group {
+    display: table;
+    border-collapse: separate;
+    & .ao-form-control {
+      display: table-cell;
+      width: 100%;
+      margin-bottom: 0;
+      &:first-child {
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+      }
+    }
+    &__addon {
+      align-items: center;
+      height: $input-height-base;
+      padding: $spacer-micro $spacer-sm;
+      font-size: $font-size-base;
+      font-weight: normal;
+      color: $color-gray-20;
+      text-align: center;
+      background-color: $color-gray-80;
+      border: 1px solid $input-border-color;
+      border-radius: $input-border-radius;
+      width: 1%;
+      white-space: nowrap;
+      vertical-align: middle;
+      display: table-cell;
+      &:last-child {
+        border-left: 0;
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+      }
+    }
+  }
+  .ao-form-group {
+    margin-bottom: $spacer;
+    label {
+      display: inline-block;
+      max-width: 100%;
+      margin: $input-label-margin;
+      font-weight: $font-weight-bold;
+    }
+  }
+}

--- a/docs/.vuepress/style.styl
+++ b/docs/.vuepress/style.styl
@@ -1,0 +1,12 @@
+* {
+  box-sizing: border-box;
+}
+
+.component-example {
+  padding: 1rem;
+  background: #f9f9f9;
+  margin-bottom: 1rem;
+}
+
+.component-controls__group {
+}

--- a/docs/components/Button.md
+++ b/docs/components/Button.md
@@ -1,0 +1,30 @@
+# Button
+
+This is a customizable button component
+
+## Examples
+
+<Doc-Button/>
+
+
+## Code Example
+```html
+<ao-button
+  primary>
+  New
+</ao-button>
+```
+
+## Props
+
+| Name        | Type    | Description                                                                                                  |
+|-------------|---------|--------------------------------------------------------------------------------------------------------------|
+| primary     | Boolean | This prop defines the button to act as a primary action ie. submition, confirmation etc.                     |
+| destructive | Boolean | This prop defines the button to act as a destructive action ie. deletion, permenant irreversable action etc. |
+| caution     | Boolean | This prop defines the button to act as a cautious action ie. reversable powerful change etc.                 |
+| subtle      | Boolean | This prop defines the button to be a more subtle version of the default button                               |
+| small       | Boolean | This prop defines a small sized button                                                                       |
+| large       | Boolean | This prop defines a large sized button                                                                       |
+| jumbo       | Boolean | This prop defines a jumbo sized button                                                                       |
+| naked       | Boolean | This prop defines a button that lacks button like visual properties button                                   |
+| disabled    | Boolean | This prop disables the button                                                                                |

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -1,0 +1,7 @@
+---
+sidebarDepth: 0
+---
+
+# Overview
+
+Blaze component library for all of your UI building needs

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "sass-loader": "^7.0.3",
     "vue-router": "^3.0.1",
     "vue-template-compiler": "^2.5.16",
-    "vuepress": "^0.12.0"
+    "vuepress": "^0.13.1"
   },
   "babel": {
     "presets": [

--- a/src/assets/styles/settings/_reset.scss
+++ b/src/assets/styles/settings/_reset.scss
@@ -1,9 +1,13 @@
 // Reset
 
-/* http://meyerweb.com/eric/tools/css/reset/ 
+/* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
    License: none (public domain)
 */
+
+* {
+	box-sizing: border-box;
+}
 
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
@@ -14,8 +18,8 @@ b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
 	margin: 0;
@@ -26,7 +30,7 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
+article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
@@ -54,8 +58,4 @@ button {
 	cursor: pointer;
   vertical-align: middle;
   background-image: none;
-}
-
-* {
-	box-sizing: border-box;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8486,9 +8486,9 @@ regexpu-core@^4.1.3, regexpu-core@^4.1.4:
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.0.2"
 
-register-service-worker@^1.2.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/register-service-worker/-/register-service-worker-1.4.0.tgz#342e417cc3044c97a660aa6b4ab4705f0146221e"
+register-service-worker@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/register-service-worker/-/register-service-worker-1.4.1.tgz#4b4c9b4200fc697942c6ae7d611349587b992b2f"
 
 registry-auth-token@^3.0.1:
   version "3.3.2"
@@ -10372,9 +10372,9 @@ vuepress-html-webpack-plugin@^3.2.0:
     toposort "^1.0.0"
     util.promisify "1.0.0"
 
-vuepress@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/vuepress/-/vuepress-0.12.0.tgz#1a268c34622fa5869db3883da5e0f9ef8609d5a0"
+vuepress@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/vuepress/-/vuepress-0.13.1.tgz#73178d58f5b0660f7dbbdd4172b0170051eb1ea9"
   dependencies:
     "@babel/core" "7.0.0-beta.47"
     "@vue/babel-preset-app" "3.0.0-beta.11"
@@ -10414,7 +10414,7 @@ vuepress@^0.12.0:
     portfinder "^1.0.13"
     postcss-loader "^2.1.5"
     prismjs "^1.13.0"
-    register-service-worker "^1.2.0"
+    register-service-worker "^1.4.1"
     semver "^5.5.0"
     stylus "^0.54.5"
     stylus-loader "^3.0.2"


### PR DESCRIPTION
This is the button for docs, and full setup of having our components readily available for creation

this is the more techincal portion of this and not the final result for v1, this will go through the tech writers at some point but the goal is to the function of the docs themselves eg routing and dynamic prop changing

this has some really gross unescessary looking scss stuff, but with this version of vuepress it seems necessary afaik, i will in the near future to cleaning it up. cssnano(built into vue-cli) handles all duplication really well so im not too worried in the meantime


# QA 
pull the repo
run ``` yarn && yarn docs:dev``` to spin up the server
click components and navigate to button
make sure allt he selects/inputs and checkboxes affect the component, and make sure all the props are accounted for (except formName? gonna include that in a future form building advanced usage kind of thing)