### PR TITLE
Create 'name' prop, file upload component is not hidden

### DIFF
--- a/docs/.vuepress/components/AoFileUpload.vue
+++ b/docs/.vuepress/components/AoFileUpload.vue
@@ -1,8 +1,7 @@
 <template>
   <label
-    v-show="showLabel"
     class="ao-form-group">
-    {{ label }}
+    <span v-show="showLabel">{{ label }}</span>
     <input
       :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
       :name="name"
@@ -33,6 +32,11 @@ export default {
     invalid: {
       type: Boolean,
       default: false
+    },
+
+    name: {
+      type: String,
+      required: true
     }
   },
 

--- a/src/components/AoFileUpload.vue
+++ b/src/components/AoFileUpload.vue
@@ -1,8 +1,7 @@
 <template>
   <label
-    v-show="showLabel"
     class="ao-form-group">
-    {{ label }}
+    <span v-show="showLabel">{{ label }}</span>
     <input
       :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
       :name="name"
@@ -33,6 +32,11 @@ export default {
     invalid: {
       type: Boolean,
       default: false
+    },
+
+    name: {
+      type: String,
+      required: true
     }
   },
 


### PR DESCRIPTION
Inside the file upload component, the 'name' property is referenced but not defined, which resulted in Vue errors.

Additionally, the 'showLabel' property was attached to the label which is wrapped around the input element. When showLabel is false, the entire component would be hidden, instead of just the label text.

This PR fixes the above to render the FileUpload component properly.