### PR TITLE
Clean up documentation for release

### DIFF
--- a/docs/.vuepress/_variables.scss
+++ b/docs/.vuepress/_variables.scss
@@ -8,9 +8,9 @@
 // Color system
 //
 
-$color-primary:            #00a38b;
-$color-primary-dark:       darken($color-primary, 5);
-$color-dark:               #292F3B;
+$color-primary:               #00a38b;
+$color-primary-dark:          darken($color-primary, 5);
+$color-dark:                  #292F3B;
 
 $color-white:                 #fff;
 $color-green:                 #17a66c;
@@ -31,7 +31,7 @@ $color-gray-50:               #ccc;
 $color-gray-60:               #dcdedf;
 $color-gray-80:               #ebecef;
 $color-gray-90:               #f7f7f9;
-$color-grey-light:              #ddd;
+$color-grey-light:            #ddd;
 
 //
 // Spacing & Sizing
@@ -69,7 +69,7 @@ $line-height-base:            1.4;
 // Layout
 //
 
-$layout-background-color:    $color-gray-90;
+$layout-background-color:     $color-gray-90;
 
 $zindex-dropdown:             1000;
 $zindex-sticky:               1020;

--- a/docs/.vuepress/components/AoButton.vue
+++ b/docs/.vuepress/components/AoButton.vue
@@ -108,6 +108,7 @@ export default {
   border-radius: $border-radius-base;
   min-height: $input-height-base;
   box-shadow: $shadow-subtle;
+  cursor: pointer;
 
  /* Default styles, overridden by special classes */
   background-color: $color-white;

--- a/docs/.vuepress/components/AoCheckbox.vue
+++ b/docs/.vuepress/components/AoCheckbox.vue
@@ -27,7 +27,7 @@ export default {
 
     checkboxValue: {
       type: [String, Number, Boolean, Object],
-      default: null
+      required: true
     },
 
     showLabel: {

--- a/docs/.vuepress/components/Doc/Alert.vue
+++ b/docs/.vuepress/components/Doc/Alert.vue
@@ -3,11 +3,11 @@
     <div class="component-example component-example__alert">
       <ao-alert
         v-if="showAlert"
-        :showAlert="showAlert"
+        :show-alert="showAlert"
         :destructive="activateProp('destructive')"
-        :caution="activateProp('caution')">
-        <span slot="alert-icon"> Icon </span>
-        <span> {{ alertText }} </span>
+        :caution="activateProp('caution')"
+        :icon-class="'glyphicon glyphicon-ok'">
+        {{ alertText }}
       </ao-alert>
     </div>
     <div class="component-controls">
@@ -20,15 +20,20 @@
       </div>
       <div class="component-controls__group">
         <ao-select
-          label="Context"
-          v-model="selectedType">
-          <option v-for="prop in alertTypes" :value="prop.value">{{ prop.name }}</option>
+          v-model="selectedType"
+          label="Context">
+          <option
+            v-for="prop in alertTypes"
+            :value="prop.value"
+            :key="prop.name">
+            {{ prop.name }}
+          </option>
         </ao-select>
       </div>
       <div class="component-controls__group">
         <ao-checkbox
           v-model="showAlert"
-          :checkbox-label="'Show Alert'"
+          :checkbox-label="'showAlert'"
           :checkbox-value="true"
         />
       </div>
@@ -39,21 +44,20 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
-      alertText: 'Text',
+      alertText: 'Alert text goes here',
       showAlert: true,
       alertTypes: [
         { value: null, name: 'Default' },
         { value: 'destructive', name: 'Destructive' },
         { value: 'caution', name: 'Caution' }
       ],
-      selectedType: null,
-      iconClass: 'test'
+      selectedType: null
     }
   },
   methods: {
-    activateProp(compare) {
+    activateProp (compare) {
       return compare === this.selectedType
     }
   }

--- a/docs/.vuepress/components/Doc/Badge.vue
+++ b/docs/.vuepress/components/Doc/Badge.vue
@@ -18,9 +18,12 @@
       </div>
       <div class="component-controls__group">
         <ao-select
-          label="Context"
-          v-model="selectedType">
-          <option v-for="(prop, index) in badgeTypes" :key="index" :value="prop.value">{{ prop.name }}</option>
+          v-model="selectedType"
+          label="Context">
+          <option
+            v-for="(prop, index) in badgeTypes"
+            :key="index"
+            :value="prop.value">{{ prop.name }}</option>
         </ao-select>
       </div>
     </div>
@@ -30,20 +33,20 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
-      text: 'Text',
+      text: 'new',
       badgeTypes: [
-        { value: 'success', name: 'Success'},
-        { value: 'info', name: 'Info'},
-        { value: 'subtle', name: 'Subtle'}
+        { value: 'success', name: 'success' },
+        { value: 'info', name: 'info' },
+        { value: 'subtle', name: 'subtle' }
       ],
       selectedType: 'success'
     }
   },
 
-   methods: {
-    activateProp(compare) {
+  methods: {
+    activateProp (compare) {
       return compare === this.selectedType
     }
   }

--- a/docs/.vuepress/components/Doc/Button.vue
+++ b/docs/.vuepress/components/Doc/Button.vue
@@ -24,22 +24,28 @@
       </div>
       <div class="component-controls__group">
         <ao-select
-          label="Context"
-          v-model="selectedContext">
-          <option v-for="(prop, index) in contextProps" :key="index" :value="prop.value">{{ prop.name }}</option>
+          v-model="selectedContext"
+          label="Context">
+          <option
+            v-for="(prop, index) in contextProps"
+            :key="index"
+            :value="prop.value">{{ prop.name }}</option>
         </ao-select>
       </div>
       <div class="component-controls__group">
         <ao-select
-          label="Size"
-          v-model="selectedSize">
-          <option v-for="(prop, index) in sizeProps" :key="index" :value="prop.value">{{ prop.name }}</option>
+          v-model="selectedSize"
+          label="Size">
+          <option
+            v-for="(prop, index) in sizeProps"
+            :key="index"
+            :value="prop.value">{{ prop.name }}</option>
         </ao-select>
       </div>
       <div class="component-controls__group">
         <ao-checkbox
           v-model="disabled"
-          :checkbox-label="'Disabled'"
+          :checkbox-label="'disabled'"
           :checkbox-value="true"
         />
       </div>
@@ -50,9 +56,9 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
-      buttonText: 'Text',
+      buttonText: 'I\'m a button',
       contextProps: [
         {name: 'Default', value: null},
         {name: 'Primary', value: 'primary'},
@@ -63,18 +69,18 @@ export default {
       ],
       selectedContext: null,
       sizeProps: [
-        {name: 'Default', value: null},
+        {name: 'Default', value: 'default'},
         {name: 'Small', value: 'small'},
         {name: 'Large', value: 'large'},
-        {name: 'Jumbo', value: 'jumbo'},
-        ],
-      selectedSize: "default",
+        {name: 'Jumbo', value: 'jumbo'}
+      ],
+      selectedSize: 'default',
       disabled: false
     }
   },
 
   methods: {
-    activateProp(compare) {
+    activateProp (compare) {
       return compare === this.selectedContext || compare === this.selectedSize
     }
   }

--- a/docs/.vuepress/components/Doc/Card.vue
+++ b/docs/.vuepress/components/Doc/Card.vue
@@ -3,15 +3,12 @@
     <div class="component-example">
       <ao-card
         :title="titleText">
-        <p v-model="slotText">
-          {{ slotText }}
-        </p>
+        <p>{{ slotText }}</p>
         <ao-button
           primary>
           Action 1
         </ao-button>
-        <ao-button
-          v-show="buttonTwo">
+        <ao-button>
           Action 2
         </ao-button>
       </ao-card>
@@ -20,14 +17,11 @@
       <ao-input
         v-model="titleText"
         :type="'text'"
-        label="Card Title" />
+        label="Card Title Text" />
       <ao-input
         v-model="slotText"
         :type="'text'"
-        label="Slot Elements" />
-      <ao-checkbox
-        v-model="buttonTwo"
-        :checkbox-label="buttonActionLabel" />
+        label="Card Content Text" />
     </div>
   </div>
 </template>
@@ -37,14 +31,7 @@ export default {
   data () {
     return {
       titleText: 'Title goes here',
-      slotText: 'She sells seashells by the sea shore',
-      buttonTwo: false
-    }
-  },
-
-  computed: {
-    buttonActionLabel () {
-      return this.buttonTwo ? 'Remove button component' : 'Add another button component'
+      slotText: 'She sells seashells by the sea shore'
     }
   }
 }

--- a/docs/.vuepress/components/Doc/Checkbox.vue
+++ b/docs/.vuepress/components/Doc/Checkbox.vue
@@ -5,6 +5,7 @@
         :checkbox-label="checkboxLabel"
         :show-label="showLabel"
         :disabled="disabled"
+        :checkbox-value="true"
       />
     </div>
     <div class="component-controls">
@@ -12,7 +13,7 @@
         <ao-input
           v-model="checkboxLabel"
           :type="'text'"
-          :label="'Alert Text'"
+          :label="'Checkbox Label Text'"
         />
       </div>
       <div class="component-controls__group">
@@ -25,7 +26,7 @@
       <div class="component-controls__group">
         <ao-checkbox
           v-model="disabled"
-          :checkbox-label="'Disabled'"
+          :checkbox-label="'disabled'"
           :checkbox-value="true"
         />
       </div>
@@ -36,15 +37,15 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
       disabled: false,
       showLabel: true,
-      checkboxLabel: 'Label'
+      checkboxLabel: 'This is the checkbox label'
     }
   },
   methods: {
-    activateProp(compare) {
+    activateProp (compare) {
       return compare === this.selectedType
     }
   }

--- a/docs/.vuepress/components/Doc/FileUpload.vue
+++ b/docs/.vuepress/components/Doc/FileUpload.vue
@@ -3,10 +3,10 @@
     <div class="component-example component-example__file-upload">
       <ao-file-upload
         :label="labelText"
-        name="'file'"
-        :showLabel="showLabel"
+        :show-label="showLabel"
         :disabled="disabled"
         :invalid="invalid"
+        name="'file'"
       />
     </div>
     <div class="component-controls">
@@ -14,7 +14,7 @@
         <ao-input
           v-model="labelText"
           :type="'text'"
-          :label="'Label Text'"
+          :label="'File Upload Label Text'"
         />
       </div>
       <div class="component-controls__group">

--- a/docs/.vuepress/components/Doc/InfoPair.vue
+++ b/docs/.vuepress/components/Doc/InfoPair.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="component-example">
       <ao-info-pair :label="label">
-        {{info}}
+        {{ info }}
       </ao-info-pair>
     </div>
     <div class="component-controls">
@@ -10,7 +10,7 @@
         <ao-input
           v-model="label"
           :type="'text'"
-          :label="'Info Pair Label'"
+          :label="'Info Pair Label Text'"
         />
       </div>
     </div>
@@ -19,7 +19,7 @@
         <ao-input
           v-model="info"
           :type="'text'"
-          :label="'Info Pair Info'"
+          :label="'Info Pair Text'"
         />
       </div>
     </div>
@@ -29,10 +29,10 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
-      label: 'Label',
-      info: 'Info'
+      label: 'Info Label',
+      info: 'Information goes here'
     }
   }
 }

--- a/docs/.vuepress/components/Doc/Input.vue
+++ b/docs/.vuepress/components/Doc/Input.vue
@@ -1,118 +1,143 @@
-  <template>
-    <div>
-      <h4>Text Input Example</h4>
-      <div class="component-example">
+<template>
+  <div>
+    <h3>Text Input Example</h3>
+    <div class="component-example">
+      <ao-input
+        :label="textLabel"
+        :placeholder="textPlaceholder"
+        :show-label="showLabel"
+        :icon-html="iconHtml"
+        :disabled="disabled"
+        :invalid="invalid"
+      />
+    </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
         <ao-input
-          :label="textLabel"
-          :placeholder="textPlaceholder"
-          :showLabel="showLabel"
-          :iconHtml="iconHtml"
-          :addOn="addOn"
-          :disabled="disabled"
-          :invalid="invalid"
+          v-model="textLabel"
+          :type="'text'"
+          :label="'Input Label Text'"
         />
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="textLabel"
-            :type="'text'"
-            :label="'Text Label'"
-          />
-        </div>
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="textPlaceholder"
-            :type="'text'"
-            :label="'Text Placeholder'"
-          />
-        </div>
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="iconHtml"
-            :type="'text'"
-            :label="'Icon'"
-          />
-        </div>
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="addOn"
-            :type="'text'"
-            :label="'Add On'"
-          />
-        </div>
-      </div>
-      <div class="component-controls__group">
-        <ao-checkbox
-          v-model="showLabel"
-          :checkbox-label="'Show Label'"
-          :checkbox-value="true"
-        />
-      </div>
-      <div class="component-controls__group">
-        <ao-checkbox
-          v-model="disabled"
-          :checkbox-label="'Disabled'"
-          :checkbox-value="false"
-        />
-      </div>
-      <div class="component-controls__group">
-        <ao-checkbox
-          v-model="invalid"
-          :checkbox-label="'Invalid'"
-          :checkbox-value="true"
-        />
-      </div>
-      <h4>Number Input Example</h4>
-      <div class="component-example">
-        <ao-input
-          type="number"
-          :label="numberLabel"
-          :step="step"
-        />
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="numberLabel"
-            :type="'text'"
-            :label="'Number Label'"
-          />
-        </div>
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="step"
-            :type="'number'"
-            :label="'Step Amount'"
-          />
-        </div>
       </div>
     </div>
-  </template>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model="textPlaceholder"
+          :type="'text'"
+          :label="'Placeholder Text'"
+        />
+      </div>
+    </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model="iconHtml"
+          :type="'text'"
+          :label="'iconHtml'"
+        />
+      </div>
+    </div>
+    <div class="component-controls__group">
+      <ao-checkbox
+        v-model="showLabel"
+        :checkbox-label="'showLabel'"
+        :checkbox-value="true"
+      />
+    </div>
+    <div class="component-controls__group">
+      <ao-checkbox
+        v-model="disabled"
+        :checkbox-label="'disabled'"
+        :checkbox-value="false"
+      />
+    </div>
+    <div class="component-controls__group">
+      <ao-checkbox
+        v-model="invalid"
+        :checkbox-label="'invalid'"
+        :checkbox-value="true"
+      />
+    </div>
+    <h3 class="component-sub-example">Number Input Example</h3>
+    <div class="component-example">
+      <ao-input
+        :label="numberLabel"
+        :step="step"
+        :add-on="addOn"
+        type="number"
+      />
+    </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model="numberLabel"
+          :type="'text'"
+          :label="'Input Label Text'"
+        />
+      </div>
+    </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model="step"
+          :type="'number'"
+          :label="'Step Amount'"
+        />
+      </div>
+    </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model="addOn"
+          :type="'text'"
+          :label="'addOn'"
+        />
+      </div>
+    </div>
+    <h3 class="component-sub-example">Date Input Example</h3>
+    <div class="component-example">
+      <ao-input
+        :label="dateLabel"
+        type="date"
+      />
+    </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model="dateLabel"
+          :type="'text'"
+          :label="'Input Label Text'"
+        />
+      </div>
+    </div>
+  </div>
+</template>
 
-  <script>
+<script>
 
-  export default {
-    data() {
-      return {
-        textLabel: 'Text Type Label',
-        textPlaceholder: 'Text Placeholder',
-        showLabel: true,
-        iconHtml: 'Icon',
-        addOn: 'Add On',
-        disabled: false,
-        invalid: false,
-        numberLabel: 'Number Type Label',
-        step: 1,
-      }
+export default {
+  data () {
+    return {
+      textLabel: 'Enter your name',
+      textPlaceholder: 'e.g. Tandy Miller',
+      showLabel: true,
+      iconHtml: '&#10004;',
+      addOn: 'years',
+      disabled: false,
+      invalid: false,
+      numberLabel: 'Enter your age',
+      step: 1,
+      dateLabel: 'Enter your date of birth'
     }
   }
-  </script>
+}
+</script>
+
+<style scoped>
+.component-sub-example {
+  border-top: 1px solid #eaecef;
+  padding-top: 5px;
+  margin-top: 50px;
+}
+</style>

--- a/docs/.vuepress/components/Doc/Modal.vue
+++ b/docs/.vuepress/components/Doc/Modal.vue
@@ -5,6 +5,8 @@
       <ao-modal
         v-if="showModal"
         :header-text="headerText"
+        :destructive="selectedRadio === 'destructive'"
+        :caution="selectedRadio === 'caution'"
         @modalClose="toggleModal">
         <div slot="modal-body">
           <p>{{ contentText }}</p>
@@ -36,17 +38,34 @@
         />
       </div>
     </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-radio
+          v-for="radio in radios"
+          :key="radio.value"
+          :val="radio.value"
+          :name="radio.name"
+          :label="radio.name"
+          v-model="selectedRadio" />
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
 
 export default {
-  data() {
+  data () {
     return {
       showModal: false,
-      headerText: 'Header Text',
-      contentText: 'I am context'
+      headerText: 'This is the modal title',
+      contentText: 'And I live in the body of the modal',
+      radios: [
+        { name: 'default', value: 'default' },
+        { name: 'destructive', value: 'destructive' },
+        { name: 'caution', value: 'caution' }
+      ],
+      selectedRadio: 'default'
     }
   },
 

--- a/docs/.vuepress/components/Doc/Navbar.vue
+++ b/docs/.vuepress/components/Doc/Navbar.vue
@@ -15,12 +15,12 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
       routes: [
-        { path: '#examples', name: 'Examples'},
-        { path: '#code-example', name: 'Code Example'},
-        { path: '#props', name: 'Props'},
+        { path: '#examples', name: 'Examples' },
+        { path: '#code-example', name: 'Code Example' },
+        { path: '#props', name: 'Props' }
       ]
     }
   }

--- a/docs/.vuepress/components/Doc/Paginate.vue
+++ b/docs/.vuepress/components/Doc/Paginate.vue
@@ -1,43 +1,41 @@
-  <template>
-    <div>
-      <div class="component-example">
-        <ao-paginate
-          :total-pages="totalPages"
-          @paginate="paginate">
-        </ao-paginate>
-        <p>Page counter (not part of component)</p>
-        <p>current page: {{currentPage}}</p>
-        <p>totalPages: {{totalPages}}</p>
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="totalPages"
-            :type="'number'"
-            :label="'Total Pages'"
-          />
-        </div>
+<template>
+  <div>
+    <div class="component-example">
+      <ao-paginate
+        :total-pages="totalPages"
+        @paginate="paginate"/>
+      <p>Current Page: {{ currentPage }}</p>
+      <p>Total Pages: {{ totalPages }}</p>
+    </div>
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model.number="totalPages"
+          :type="'number'"
+          :label="'Total Pages'"
+        />
       </div>
     </div>
-  </template>
+  </div>
+</template>
 
-  <script>
+<script>
+export default {
+  data () {
+    return {
+      totalPages: 3,
+      currentPage: 1
+    }
+  },
 
-  export default {
-    data() {
-      return {
-        totalPages: 3,
-        currentPage: 1
-      }
-    },
-
-    methods:{
-      paginate (page) {
-        this.currentPage = page
-      }
+  methods: {
+    paginate (page) {
+      this.currentPage = page
     }
   }
-  </script>
+}
+</script>
+
 <style lang="scss" scoped>
 .ao-pagination {
   width: fit-content !important;

--- a/docs/.vuepress/components/Doc/Radio.vue
+++ b/docs/.vuepress/components/Doc/Radio.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="component-example">
-      <div class="component-example__display"> My favourite character is {{selectedRadio}} </div>
+      <div class="component-example__display"> My favourite character is {{ selectedRadio }} </div>
       <ao-radio
         v-for="radio in radios"
         :key="radio.value"
@@ -16,7 +16,7 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
       radios: [
         { name: 'Tandy', value: 'Tandy' },

--- a/docs/.vuepress/components/Doc/SectionHeader.vue
+++ b/docs/.vuepress/components/Doc/SectionHeader.vue
@@ -3,8 +3,9 @@
     <div class="component-example">
       <ao-section-header
         :title="title"
-        :subtitle="subtitle">
-      </ao-section-header>
+        :subtitle="subtitle"
+        :icon-html="iconHtml"
+      />
     </div>
     <div class="component-controls">
       <div class="component-controls__group">
@@ -18,7 +19,14 @@
         <ao-input
           v-model="subtitle"
           :type="'text'"
-          :label="'Section Header SubTitle'"
+          :label="'Section Header Subtitle'"
+        />
+      </div>
+      <div class="component-controls__group">
+        <ao-input
+          v-model="iconHtml"
+          :type="'text'"
+          :label="'iconHtml'"
         />
       </div>
     </div>
@@ -28,10 +36,11 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
-      title: 'Section Header Title',
-      subtitle: 'This is a subtitle'
+      title: 'This is the section header title',
+      subtitle: 'The subtitle goes here',
+      iconHtml: 'Hello!'
     }
   }
 }

--- a/docs/.vuepress/components/Doc/Select.vue
+++ b/docs/.vuepress/components/Doc/Select.vue
@@ -1,18 +1,19 @@
 <template>
   <div>
     <div class="component-example">
-      <div class="component-example__display"> My favourite Pokemon is {{selected}} </div>
+      <div class="component-example__display">My favourite Pokemon is {{ selected }} </div>
       <ao-select
         v-model="selected"
         :label="label"
         :placeholder="placeholder"
         :invalid="invalid"
         :disabled="disabled"
-        :showLabel="showLabel">
+        :show-label="showLabel">
         <option
           v-for="option in options"
-          :value="option.value">
-          {{option.name}}
+          :value="option.value"
+          :key="option.name">
+          {{ option.name }}
         </option>
       </ao-select>
     </div>
@@ -33,13 +34,6 @@
       </div>
       <div class="component-controls__group">
         <ao-checkbox
-          v-model="invalid"
-          :checkbox-label="'Invalid'"
-          :checkbox-value="true"
-        />
-      </div>
-      <div class="component-controls__group">
-        <ao-checkbox
           v-model="showLabel"
           :checkbox-label="'showLabel'"
           :checkbox-value="true"
@@ -48,7 +42,14 @@
       <div class="component-controls__group">
         <ao-checkbox
           v-model="disabled"
-          :checkbox-label="'Disabled'"
+          :checkbox-label="'disabled'"
+          :checkbox-value="true"
+        />
+      </div>
+      <div class="component-controls__group">
+        <ao-checkbox
+          v-model="invalid"
+          :checkbox-label="'invalid'"
           :checkbox-value="true"
         />
       </div>
@@ -59,7 +60,7 @@
 <script>
 
 export default {
-  data() {
+  data () {
     return {
       label: 'Select Label',
       placeholder: 'Select Pokemon',
@@ -76,7 +77,7 @@ export default {
     }
   },
   methods: {
-    activateProp(compare) {
+    activateProp (compare) {
       return compare === this.selectedType
     }
   }

--- a/docs/.vuepress/components/Doc/Table.vue
+++ b/docs/.vuepress/components/Doc/Table.vue
@@ -6,6 +6,7 @@
         :is-clickable="isClickable"
         :sort-by="sortBy"
         :order="order"
+        class="fixed-widths"
         @sortTable="sortTable">
         <tr
           v-for="user in users"
@@ -31,16 +32,16 @@ export default {
         { field: 'last_name', title: 'Last Name', sortable: true }
       ],
       users: [
-        { 'id': 1, 'first_name': 'Jesse', 'last_name': 'Simmons'},
-        { 'id': 2, 'first_name': 'John', 'last_name': 'Jacobs'},
-        { 'id': 3, 'first_name': 'Tina', 'last_name': 'Gilbert'},
-        { 'id': 4, 'first_name': 'Clarence', 'last_name': 'Flores'},
-        { 'id': 5, 'first_name': 'Anne', 'last_name': 'Lee'},
-        { 'id': 6, 'first_name': 'Rick', 'last_name': 'Potter'},
-        { 'id': 7, 'first_name': 'Harry', 'last_name': 'Sanchez'},
-        { 'id': 8, 'first_name': 'Joy', 'last_name': 'Mann'},
-        { 'id': 9, 'first_name': 'Adam', 'last_name': 'Hansen'},
-        { 'id': 10, 'first_name': 'Marge', 'last_name': 'Grey'}
+        { 'id': 1, 'first_name': 'Jesse', 'last_name': 'Simmons' },
+        { 'id': 2, 'first_name': 'John', 'last_name': 'Jacobs' },
+        { 'id': 3, 'first_name': 'Tina', 'last_name': 'Gilbert' },
+        { 'id': 4, 'first_name': 'Clarence', 'last_name': 'Flores' },
+        { 'id': 5, 'first_name': 'Anne', 'last_name': 'Lee' },
+        { 'id': 6, 'first_name': 'Rick', 'last_name': 'Potter' },
+        { 'id': 7, 'first_name': 'Harry', 'last_name': 'Sanchez' },
+        { 'id': 8, 'first_name': 'Joy', 'last_name': 'Mann' },
+        { 'id': 9, 'first_name': 'Adam', 'last_name': 'Hansen' },
+        { 'id': 10, 'first_name': 'Marge', 'last_name': 'Grey' }
       ],
       sortBy: 'id',
       order: 'asc',
@@ -55,3 +56,13 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.fixed-widths td {
+  width: 200px;
+
+  &:first-child {
+    width: 50px;
+  }
+}
+</style>

--- a/docs/.vuepress/components/Doc/TextArea.vue
+++ b/docs/.vuepress/components/Doc/TextArea.vue
@@ -1,78 +1,75 @@
 <template>
-<div>
-  <div class="component-example">
-    <ao-text-area
-      :showLabel="showLabel"
-      :label="textAreaText"
-      :placeholder="placeholderText"
-      :rows="rowLength"
-      :maxLength="maxCharacters"
-      :disabled="disabled"
-      :invalid="invalid">
-    </ao-text-area>
-  </div>
-  <div class="component-controls">
-    <div class="component-controls__group">
-      <ao-input
-        v-model="textAreaText"
-        :type="'text'"
-        :label="'Text Area Label Text'"
-      />
+  <div>
+    <div class="component-example">
+      <ao-text-area
+        :show-label="showLabel"
+        :label="textAreaText"
+        :placeholder="placeholderText"
+        :rows="rowLength"
+        :max-length="maxCharacters"
+        :disabled="disabled"
+        :invalid="invalid" />
     </div>
-    <div class="component-controls__group">
-      <ao-input
-        v-model="placeholderText"
-        :type="'text'"
-        :label="'Text Area Placeholder Text'"
-      />
-    </div>
-    <div class="component-controls__group">
-      <ao-input
-        v-model="rowLength"
-        :type="'number'"
-        :label="'Text Area Number of Rows'">
-      </ao-input>
-    </div>
-    <div class="component-controls__group">
-      <ao-input
-        v-model="maxCharacters"
-        :type="'number'"
-        :label="'Text Area Maximum Character Length'">
-      </ao-input>
-    </div>
-    <div class="component-controls__group">
-      <ao-checkbox
-        v-model="showLabel"
-        :checkbox-label="'showLabel'"
-        :checkbox-value="true" />
-    </div>
-    <div class="component-controls__group">
-      <ao-checkbox
-        v-model="disabled"
-        :checkbox-label="'disabled'"
-        :checkbox-value="true" />
-    </div>
-    <div class="component-controls__group">
-      <ao-checkbox
-        v-model="invalid"
-        :checkbox-label="'invalid'"
-        :checkbox-value="true" />
+    <div class="component-controls">
+      <div class="component-controls__group">
+        <ao-input
+          v-model="textAreaText"
+          :type="'text'"
+          :label="'Text Area Label Text'"
+        />
+      </div>
+      <div class="component-controls__group">
+        <ao-input
+          v-model="placeholderText"
+          :type="'text'"
+          :label="'Text Area Placeholder Text'"
+        />
+      </div>
+      <div class="component-controls__group">
+        <ao-input
+          v-model="rowLength"
+          :type="'number'"
+          :label="'Text Area Number of Rows'"/>
+      </div>
+      <div class="component-controls__group">
+        <ao-input
+          v-model="maxCharacters"
+          :type="'number'"
+          :label="'Text Area Maximum Character Length'"/>
+      </div>
+      <div class="component-controls__group">
+        <ao-checkbox
+          v-model="showLabel"
+          :checkbox-label="'showLabel'"
+          :checkbox-value="true" />
+      </div>
+      <div class="component-controls__group">
+        <ao-checkbox
+          v-model="disabled"
+          :checkbox-label="'disabled'"
+          :checkbox-value="true" />
+      </div>
+      <div class="component-controls__group">
+        <ao-checkbox
+          v-model="invalid"
+          :checkbox-label="'invalid'"
+          :checkbox-value="true" />
+      </div>
     </div>
   </div>
-</div>
 </template>
 
 <script>
 export default {
   data () {
     return {
-      placeholderText: "Ever since I was a kid, I've had a fear of being scared.",
+      placeholderText: "e.g. Ever since I was a kid, I've had a fear of being scared.",
       rowLength: 5,
       maxCharacters: 100000,
       disabled: false,
       invalid: false,
       showLabel: true,
-      textAreaText: 'Text Area'
+      textAreaText: 'Enter your favourite \'Last Man on Earth\' quote'
     }
   }
 }

--- a/docs/.vuepress/components/Doc/TextStyle.vue
+++ b/docs/.vuepress/components/Doc/TextStyle.vue
@@ -51,7 +51,7 @@
 export default {
   data () {
     return {
-      text: 'Text',
+      text: 'This is some sample text',
       selectedSize: null,
       selectedContext: null,
       sizeOptions: [

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,56 +1,56 @@
 const fs = require('fs')
 module.exports = {
   locales: {
-    "/": {
-      lang: "en-US",
-      title: "Blaze",
-      description: "Component Library created by Ample Organics"
+    '/': {
+      lang: 'en-US',
+      title: 'Blaze',
+      description: 'Component Library created by Ample Organics'
     }
   },
   serviceWorker: true,
   themeConfig: {
-    repo: "AmpleOrganics/Blaze.vue",
-    docsDir: "docs",
-    docsBranch: "master",
+    repo: 'AmpleOrganics/Blaze.vue',
+    docsDir: 'docs',
+    docsBranch: 'master',
     editLinks: true,
     sidebarDepth: 3,
     locales: {
-      "/": {
-        label: "English",
-        selectText: "Languages",
-        lastUpdated: "Last Updated",
-        editLinkText: "Edit this page on GitHub",
+      '/': {
+        label: 'English',
+        selectText: 'Languages',
+        lastUpdated: 'Last Updated',
+        editLinkText: 'Edit this page on GitHub',
         nav: [
           {
-            text: "Components",
-            link: "/components/"
+            text: 'Components',
+            link: '/components/'
           }
         ],
         sidebar: {
-          "/components/": [
-            "/components/",
+          '/components/': [
+            '/components/',
             {
-              title: "Components",
+              title: 'Components',
               collapsable: false,
               children: [
-                "/components/Alert",
-                "/components/Badge",
-                "/components/Button",
-                "/components/Card",
-                "/components/Checkbox",
-                "/components/FileUpload",
-                "/components/InfoPair",
-                "/components/Input",
-                "/components/Modal",
-                "/components/Navbar",
-                "/components/Paginate",
-                "/components/Radio",
-                "/components/SectionHeader",
-                "/components/Select",
+                '/components/Alert',
+                '/components/Badge',
+                '/components/Button',
+                '/components/Card',
+                '/components/Checkbox',
+                '/components/FileUpload',
+                '/components/InfoPair',
+                '/components/Input',
+                '/components/Modal',
+                '/components/Navbar',
+                '/components/Paginate',
+                '/components/Radio',
+                '/components/SectionHeader',
+                '/components/Select',
                 '/components/Spinner',
-                "/components/Table",
-                "/components/TextStyle",
-                "/components/TextArea"
+                '/components/Table',
+                '/components/TextArea',
+                '/components/TextStyle'
               ]
             }
           ]
@@ -60,9 +60,9 @@ module.exports = {
     css: {
       loaderOptions: {
         scss: {
-          data: fs.readFileSync("./docs/.vuepress/_variables.scss", "utf-8")
+          data: fs.readFileSync('./docs/.vuepress/_variables.scss', 'utf-8')
         }
       }
     }
   }
-};
+}

--- a/docs/.vuepress/style.styl
+++ b/docs/.vuepress/style.styl
@@ -8,9 +8,6 @@
   margin-bottom: 1rem;
 }
 
-.component-controls__group {
-}
-
 #code-example {
   margin-top: -1rem;
 }

--- a/docs/components/Alert.md
+++ b/docs/components/Alert.md
@@ -11,8 +11,8 @@ This is a customizable alert component
 <ao-alert
   v-if="showAlert"
   :showAlert="true"
-  <span slot="alert-icon"> Icon </span>
-  <span> New </span>
+  :icon-class="'glyphicon glyphicon-ok'">
+  Alert text goes here
 </ao-alert>
 ```
 
@@ -20,7 +20,7 @@ This is a customizable alert component
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| showAlert | Boolean | false | This prop defines the alert to be shown or not. |
-| iconClass | String | null | This prop defines the alert icon class. |
-| destructive | Boolean | false | This prop defines the alert to be a destructive alert. |
-| caution | Boolean | false | This prop defines the alert to be a cautious alert. |
+| showAlert | Boolean | false | Shows or hides the alert. |
+| iconClass | String | null | Displays icon components ie. glyphicons. |
+| destructive | Boolean | false | Adds a class to indicate a destructive action ie. deletion, permanent irreversible action etc. |
+| caution | Boolean | false | Adds a class to indicate a cautious action ie. reversible powerful change etc. |

--- a/docs/components/Badge.md
+++ b/docs/components/Badge.md
@@ -9,7 +9,7 @@ This is a customizable badge component
 ## Code Example
 ```html
 <ao-badge
-  :text="'text'"
+  :text="'new'"
   success
 />
 ```
@@ -18,7 +18,7 @@ This is a customizable badge component
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| text | String | null | This prop defines text within the badge component. |
-| success | Boolean | false | This prop defines the alert to show a green badge. |
-| info | Boolean | false | This prop defines the alert to show a blue badge. |
-| subtle | Boolean | false | This prop defines the alert to show a grey badge. |
+| text | String | null | The text to display within the badge component. |
+| success | Boolean | false | Adds a class to display a green badge. |
+| info | Boolean | false | Adds a class to display a blue badge. |
+| subtle | Boolean | false | Adds a class to display a grey badge. |

--- a/docs/components/Button.md
+++ b/docs/components/Button.md
@@ -10,21 +10,22 @@ This is a customizable button component
 ## Code Example
 ```html
 <ao-button
-  primary>
-  New
+  primary
+  large>
+  I'm a button
 </ao-button>
 ```
 
 ## Props
 
-| Name         | Type     | Default | Description                                                           |
-|:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| primary     | Boolean | false | This prop defines the button to act as a primary action ie. submition, confirmation etc.                     |
-| destructive | Boolean | false | This prop defines the button to act as a destructive action ie. deletion, permenant irreversable action etc. |
-| caution     | Boolean | false | This prop defines the button to act as a cautious action ie. reversable powerful change etc.                 |
-| subtle      | Boolean | false | This prop defines the button to be a more subtle version of the default button                               |
-| small       | Boolean | false | This prop defines a small sized button                                                                       |
-| large       | Boolean | false | This prop defines a large sized button                                                                       |
-| jumbo       | Boolean | false | This prop defines a jumbo sized button                                                                       |
-| naked       | Boolean | false | This prop defines a button that lacks button like visual properties button                                   |
-| disabled    | Boolean | false | This prop disables the button                                                                                |
+| Name        | Type    | Default | Description |
+|:------------|:--------|:------|:--------------|
+| primary     | Boolean | false | Adds a class to indicate a primary action ie. submission, confirmation etc.                    |
+| destructive | Boolean | false | Adds a class to indicate a destructive action ie. deletion, permanent irreversible action etc. |
+| caution     | Boolean | false | Adds a class to indicate a cautious action ie. reversible powerful change etc.                 |
+| subtle      | Boolean | false | Displays a more subtle version of the default button                                           |
+| small       | Boolean | false | Displays a small sized button                                                                  |
+| large       | Boolean | false | Displays a large sized button                                                                  |
+| jumbo       | Boolean | false | Displays a jumbo sized button                                                                  |
+| naked       | Boolean | false | Displays a style that lacks the visual properties of a button                                  |
+| disabled    | Boolean | false | Disables the button                                                                            |

--- a/docs/components/Card.md
+++ b/docs/components/Card.md
@@ -24,6 +24,6 @@ The Card component allows you to group and organize related content - text, acti
 
 ## Props
 
-| Name         | Type             | Element       | Attribute                            |
+| Name         | Type             | Default       | Attribute                            |
 |:-------------|:-----------------|:--------------|:-------------------------------------|
-| title        | String, required | &lt;h2&gt;    | Font-size: 28px                      |
+| title        | String, required | null          | Displays title text within the card header. |

--- a/docs/components/Checkbox.md
+++ b/docs/components/Checkbox.md
@@ -11,6 +11,7 @@ This is a customizable checkbox component
 <ao-checkbox
   :checkbox-label="'Label'"
   :show-label="true"
+  :checkbox-value="true"
 />
 ```
 
@@ -18,8 +19,8 @@ This is a customizable checkbox component
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| value | [Array, Boolean, Number, Object] | null | This prop defines if the checkbox is activated or not. |
-| checkboxValue | [String, Number, Boolean, Object] | null | This prop defines the value of the checkbox. |
-| showLabel | Boolean | true | This prop defines if the label should be shown or not. |
-| checkboxLabel | String | - | This prop defines the checkbox label and is required. |
-| disabled | Boolean | false | This prop defines if the checkbox is disabled or not. |
+| value | [Array, Boolean, Number, Object] | null | Defines the value associated with the input (this is also the value that is sent on submit). |
+| checkboxValue | [String, Number, Boolean, Object], required | true | Defines the value associated with the input. |
+| showLabel | Boolean | true | Hide or unhide the text label. |
+| checkboxLabel | String, required | - | Text label next to the checkbox. |
+| disabled | Boolean | false | Disables interaction with the component. |

--- a/docs/components/FileUpload.md
+++ b/docs/components/FileUpload.md
@@ -10,8 +10,8 @@ This is a customizable file upload component
 ## Code Example
 ```html
 <ao-file-upload
-  label="'Upload File'"
-  name="'File'"
+  :label="'Upload File'"
+  :name="'File'"
 />
 ```
 
@@ -19,8 +19,8 @@ This is a customizable file upload component
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| label       | String, required | null  | Displays a text label above the button to describe the action |
-| name        | String, required | null  | Specifies the name of the &lt;label&gt; element |
-| showLabel   | Boolean          | True  | Hide or unhide the text label |
-| disabled    | Boolean          | False | Disables interaction with the component |
-| invalid     | Boolean          | False | Adds a class to display a red border around the component to indicate a file type that does not meet your desired criteria |
+| label       | String, required | -     | Displays a text label above the button to describe the action |
+| name        | String, required | -     | Specifies the name of the &lt;label&gt; element |
+| showLabel   | Boolean          | true  | Hide or unhide the text label |
+| disabled    | Boolean          | false | Disables interaction with the component |
+| invalid     | Boolean          | false | Adds a class to display a red border around the component to indicate an invalid entry |

--- a/docs/components/InfoPair.md
+++ b/docs/components/InfoPair.md
@@ -8,8 +8,8 @@ This is a customizable info pair component
 
 ## Code Example
 ```html
-<ao-info-pair label="label">
-  Info
+<ao-info-pair label="'Info Label'">
+  Information goes here
 </ao-info-pair>
 ```
 
@@ -17,4 +17,4 @@ This is a customizable info pair component
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| label | String | - | This prop defines the info pair label which is required. |
+| label | String, required | - | Text displayed as the info pair label. |

--- a/docs/components/Input.md
+++ b/docs/components/Input.md
@@ -9,10 +9,27 @@ This is a customizable input component
 ## Code Example
 ```html
 <ao-input
-  :label="'Label'"
-  :placeholder="'placeholder'"
+  type="text"
+  :label="'Enter your name'"
+  :placeholder="'e.g. Tandy Miller'"
   :showLabel="true"
-  :addOn="'mL'"
+  :iconHtml="'&#10004;'"
+/>
+```
+
+```html
+<ao-input
+  type="number"
+  :label="'Enter your age'"
+  :step="1"
+  :addOn="'years'"
+/>
+```
+
+```html
+<ao-input
+  type="date"
+  :label="'Enter your date of birth'"
 />
 ```
 
@@ -20,15 +37,15 @@ This is a customizable input component
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| type | String | text | This prop defines the input's type. Types that are included are: text, number, email, password, date, and search. |
-| value | [String, Number] | null | This prop defines the value of the input. |
-| label | String | - | This prop defines the input label which is required. |
-| showLabel | Boolean | true | This prop defines if the label should be shown or not. |
-| name | String | null | This prop defines the html name property and has no functional purpose on its own. |
-| placeholder | String | null | This prop defines the placeholder inside of the input. |
-| iconHtml | String | null | This prop defines the icon's html. |
-| iconClass | String | null | This prop defines the icon's class. |
-| addOn | String | null | This prop renders a string that appears after the input. |
-| disabled | Boolean | false | This prop defines if the input is disabled or not. |
-| step | Number | 1 | If the input's type is a number this prop defines the amount of changes per click. |
-| invalid | Boolean | false | This prop defines if the input is invalid or not. |
+| type | String | text | Defines the input type. <br /><strong>Accepted types: text, number, email, password, date, search.</strong> |
+| value | [String, Number] | null | Defines the value of the input. |
+| label | String, required | - | Displays the text label above the input. |
+| showLabel | Boolean | true | Hide or unhide the text label. |
+| name | String | null | Defines the html name property and has no functional purpose on its own. |
+| placeholder | String | null | Defines the placeholder text inside of the input. |
+| iconHtml | String | null | Accepts html elements or html codes for icons. |
+| iconClass | String | null | Accepts icon class components e.g. glyphicons. |
+| addOn | String | null | Appends text to the input. |
+| step | Number | 1 | Valid for input type 'number'. Defines the amount of changes per click. |
+| disabled | Boolean | false | Disables interaction with the component. |
+| invalid | Boolean | false | Adds a class to display a red border around the component to indicate an invalid entry. |

--- a/docs/components/Modal.md
+++ b/docs/components/Modal.md
@@ -10,10 +10,10 @@ This is a customizable modal component
 ```html
 <ao-modal
   v-if="showModal"
-  :header-text="'Header Text'"
+  :header-text="'This is the modal title'"
   @modalClose="toggleModal">
   <div slot="modal-body">
-    <p>I am content</p>
+    <p>And I live in the body of the modal</p>
   </div>
   <div slot="modal-footer">
     <ao-button
@@ -29,7 +29,7 @@ This is a customizable modal component
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| headerText | String, required | null | This prop defines the header text in the modal. |
-| destructive | Boolean | false | This prop defines if the modal will appear destructive. |
-| caution | Boolean | false | This prop defines if the modal will appear cautious. |
+| headerText | String, required | null | Defines the modal title. |
+| destructive | Boolean | false | Adds a class to indicate a destructive action ie. deletion, permanent irreversible action etc. |
+| caution | Boolean | false | Adds a class to indicate a cautious action ie. reversible powerful change etc. |
 

--- a/docs/components/Paginate.md
+++ b/docs/components/Paginate.md
@@ -1,19 +1,21 @@
 # Paginate
 This is a pagination component allowing you to navigate between pages
 
+## Examples
+
 <Doc-Paginate/>
 
 ## Code Example
 ```html
 <ao-paginate
-  :totalPages="5"
+  :total-pages="5"
   @paginate="paginate"
 />
 ```
 
 ```js
 methods: {
-  // paginate emits current page number then allowing to do whatever you want with taht info
+  // paginate emits current page number then allowing to do whatever you want with that info
   paginate (page) {
     this.currentPage = page
   }
@@ -21,10 +23,10 @@ methods: {
 
 ```
 
-# Props
+## Props
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| totalPage | Number | 1 | This prop defines the total amount of pages that pagination can go through. |
-| @paginate | event | N/A | This bind emits current page number when it changes in the component. |
+| totalPages | Number | 1 | Defines the total number of pages through which the pagination can go. |
+| @paginate | event | N/A | Emits the current page number as it changes. |
 

--- a/docs/components/Radio.md
+++ b/docs/components/Radio.md
@@ -14,7 +14,8 @@ This is a customizable radio component
   :val="radio.value"
   :name="radio.name"
   :label="radio.name"
-  v-model="selectedRadio"/>
+  v-model="selectedRadio"
+/>
 ```
 
 ```js

--- a/docs/components/SectionHeader.md
+++ b/docs/components/SectionHeader.md
@@ -10,17 +10,17 @@ This is a customizable Section Header component
 ```html
 <ao-section-header
   :icon-class="'custom-glyph-clients'"
-  :title="'Title'"
-  :subtitle="'Subtitle'">
-</ao-section-header>
+  :title="'This is the section header title'"
+  :subtitle="'The subtitle goes here'"
+/>
 ```
 
 ## Props
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| title | String, required | null | This prop defines the title of the section header. |
-| subtitle | String | null | This prop defines the subtitle of the section header. |
-| iconHtml | String | null | This prop defines the section header icon html. |
-| iconClass | String | null | This prop defines the section header icon class. |
+| title | String, required | null | Defines the title of the section header. |
+| subtitle | String | null | Defines the subtitle of the section header. |
+| iconHtml | String | null | Accepts html elements or html codes for icons. |
+| iconClass | String | null | Accepts icon class components e.g. glyphicons. |
 

--- a/docs/components/TextArea.md
+++ b/docs/components/TextArea.md
@@ -11,23 +11,22 @@ This is a customizable textarea component
 ```html
 <ao-text-area
   label="'Text Area'"
-  placeholder="'Ever since I was a kid, I've had a fear of being scared.'"
+  placeholder="'e.g. Ever since I was a kid, I've had a fear of being scared.'"
   rows="3"
-  minLength="10">
-</ao-text-area>
+  minLength="10" />
 ```
 
 ## Props
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| value |    String |    null |    This prop defines the text area value. |
-| label |    String, required |    null |  This prop defines the label of the text area. |
-| name |    String |    null |    This prop defines the text area’s html name. |
-| placeholder |    String |    null |    This prop defines the placeholder within the text area. |
-| maxLength |    Number |    100000 |    This prop defines the max length of characters within a text area. |
-| minLength |    Number |    0 |    This prop defines the minimum length of characters within a text area. |
-| disabled |    Boolean |    false |    This prop defines if the text area should be disabled or not. |
-| rows |    Number |    5 |    This prop defines the number of rows the text area has. |
-| invalid |    Boolean |    false |    This prop defines if the text area is invalid. |
-| showLabel |    Boolean |    true |    This prop defines if the label for the text area should be shown or not. |
+| value |    String |    null |    Defines the value of the input. |
+| name |    String |    null |    Defines the text area html name. |
+| label |    String, required |    null |  Defines the text label above the text area. |
+| placeholder |    String |    null |    Defines the placeholder within the text area. |
+| showLabel |    Boolean |    true |    Hide or unhide the text label. |
+| maxLength |    Number |    100000 |    Defines the max length of characters within the text area. |
+| minLength |    Number |    0 |    Defines the minimum length of characters within the text area. |
+| rows |    Number |    5 | Defines the number of rows of the text area. |
+| disabled |    Boolean |    false |    Disables interaction with the component. |
+| invalid |    Boolean |    false |    Adds a class to display a red border around the component to indicate an invalid entry. |

--- a/docs/components/TextStyle.md
+++ b/docs/components/TextStyle.md
@@ -12,7 +12,7 @@ This is a simple customizable text component to compliment other components
 <ao-text-style
   error
   small>
-  Your text here
+  This is some sample text
 </ao-text-style>
 ```
 
@@ -20,5 +20,5 @@ This is a simple customizable text component to compliment other components
 
 | Name         | Type     | Default | Description                                                           |
 |:-------------|:---------|:---------|:----------------------------------------------------------------------|
-| error | Boolean | false | This prop defines if the text is an error message. |
-| small | Boolean | false | This prop defines size to be small instead of its default size. |
+| error | Boolean | false | Adds a class to change the font colour to red to indicate an error. |
+| small | Boolean | false | Converts font-size to 0.75rem, given a base of font-size 16px. |

--- a/src/components/AoCheckbox.vue
+++ b/src/components/AoCheckbox.vue
@@ -27,7 +27,7 @@ export default {
 
     checkboxValue: {
       type: [String, Number, Boolean, Object],
-      default: null
+      required: true
     },
 
     showLabel: {


### PR DESCRIPTION
Clean up branch for blaze documentation

TO DO:
Alert
- [ ] ~~add glyphicon or at least an img if glyphs don't work~~
- [x] remove "This prop..."
- [x] missing a closing tag on <ao-alert> in the Code example
- [x] 'showAlert' should be 'show-alert'

Badge
- [x] remove "This prop..."
- [x] update 'text' text

Button
- [x] should have the Default pre-populated in the dropdown
- [x] remove "This prop..."
- [x] change to more descriptive button text "I'm a button"

Card
- [x] should be called 'Card Title Text'
- [x] 'Card-body' slot
- [x] Props - missing 'Default' null

Checkbox
- [x] rename 'Alert Text' to 'Checkbox Label Text'
- [x] lowercase 'Disabled'
- [x] remove "This prop..."
- [x] checkboxLabel default 'null'
- [x] checkboxLabel Type should be 'String, required' and '...and is required' removed from the description

File Upload
- [x] rename 'Label Text' to 'File Upload Label Text'
- [x] change invalid description to "Adds a class to display a red border around the component to indicate an invalid entry"
- [x] lowercase "true" and "false"

Info Pair
- [x] rename "Info Pair Label" to "Info Pair Label Text"
- [x] rename "Info Pair Info" to "Info Pair Text"
- [x] rename placeholder for "Label" to "Info Label"
- [x] rename placeholder for "Info" to "Information goes here"
- [x] remove "This prop..."

Input
- [x] need better separation between the "Text Input Example" and "Number Input Example", some sort of dividing line? Or making "Text Input Example" and "Number Input Example" a larger font?
- [x] change "Text Type Label" to something more descriptive like "Text Input label goes here"
- [x] change "Text Label" to "Input Label Text"
- [x] change "Text Placeholder" to "Placeholder Text"
- [x] change "Show Label" to "showLabel", lowercase "disabled" and "invalid"
- [x] change "Number Type Label" to something more descriptive like "Number Input label goes here"
- [x] change "Number Label" to "Input Label Text"
- [x] add a code example for the text input only and another for the number input only
- [x] iconHTML and addOn seem unclear to me, what are they supposed to do or contain? They currently look like buttons in this example. Maybe separate them into separate lines if they're not supposed to be attached to the input field? -- added html code and update examples to more clearly demonstrate use-cases for the addOn and iconHtml
- [x] add a date input example

Modal
- [ ] is the font face not working for the title? - font importing issues, might not be able to do
- [ ] ~~maybe something more fun for the context text like a funny quote?~~
- [x] change "Header Text" prop to "Header Text goes here"
- [x] code example to be consistent with the text inside Context Text
- [ ] ~~add sections for the modal-body slot and modal-footer slot?~~
- [ ] ~~interactivity for the 'close' button - changing text?~~
- [x] update 'this prop...' descriptions to be consistent with the definitions in the alert component
- [x] include radio options for changing the modal colour

NavBar
- [x] remove trailing ',' after the last obj in the routes array (code example)

Paginate
- [x] missing "Examples" Header, "Examples" and "Props" not appearing in sidebar
- [x] remove "Page counter (not part of component)"
- [x] // paginate emits current page number then allowing to do whatever you want with taht info - typo in "taht"
- [x] change "totalPage:" in Props to "totalPages:"
- [ ] ~~flip the order of "current page" and "totalPage", and capitalize "Current Page:" to maybe help distinguish it from a prop?~~
- [x] fix 'invalid prop' type error, actually related to input type - Number is getting parsed as a string

Radio
- [x] move closing tag '/>' to separate line in Code Example
- [ ] ~~do we want to add interactivity with changing the label of one of the radio buttons, since a label is a prop?~~

Section Header
- [x] "SubTitle" to "Subtitle"
- [x] what is the iconHtml prop? Might need to come up with a description that we could use across all 'iconHtml' props
- [x] update Props descriptions to be more consistent with other components using the same props (e.g. Input)

Select
- [x] change to lowercase "Invalid" and "Disabled"
- [x] change order of checkboxes to "showLabel" "disabled" "invalid"

Table
- [x] any chance we can hard code the widths of the table columns in the Example?
- [ ] ~~look into importing a glyph, icon, img for the up/down sorting chevron~~

Text Style
- [x] default text in the 'Examples' should be consistent with the text inside the Code Example, e.g. "Text" vs "Your text here"
- [x] small props description, should we list the rem for users to know how much % smaller the text would be? Ie. base is 16px (1rem), small is 12px

Text Area
- [x] remove "This prop..."
- [x] needs to be moved above "Text Style" in sidebar/config

Miscellaneous
- [x] lint and fix errors in components