### PR TITLE
Add styles for other modal sizes

### DIFF
--- a/docs/components/Modal.vue
+++ b/docs/components/Modal.vue
@@ -10,9 +10,10 @@
         <ao-button @click.native="toggleModal">Open Modal</ao-button>
         <ao-modal
           v-if="showModal"
+          :size="selectedModalSize"
           :header-text="headerText"
-          :destructive="selectedRadio === 'destructive'"
-          :caution="selectedRadio === 'caution'"
+          :destructive="selectedModalType === 'destructive'"
+          :caution="selectedModalType === 'caution'"
           @modalClose="toggleModal">
           <div slot="modal-body">
             <p>{{ contentText }}</p>
@@ -47,12 +48,23 @@
       <div class="component-controls">
         <div class="component-controls__group">
           <ao-radio
-            v-for="radio in radios"
+            v-for="radio in modalTypes"
             :key="radio.value"
             :val="radio.value"
             :name="radio.name"
             :label="radio.name"
-            v-model="selectedRadio" />
+            v-model="selectedModalType" />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-radio
+            v-for="radio in modalSizes"
+            :key="radio.value"
+            :val="radio.value"
+            :name="radio.name"
+            :label="radio.name"
+            v-model="selectedModalSize" />
         </div>
       </div>
     </div>
@@ -81,12 +93,18 @@ export default {
       showModal: false,
       headerText: 'This is the modal title',
       contentText: 'And I live in the body of the modal',
-      radios: [
+      modalTypes: [
         { name: 'default', value: 'default' },
         { name: 'destructive', value: 'destructive' },
         { name: 'caution', value: 'caution' }
       ],
-      selectedRadio: 'default'
+      selectedModalType: 'default',
+      modalSizes: [
+        { name: 'small', value: 'small' },
+        { name: 'medium', value: 'medium' },
+        { name: 'large', value: 'large' }
+      ],
+      selectedModalSize: 'medium'
     }
   },
 

--- a/src/components/AoModal.vue
+++ b/src/components/AoModal.vue
@@ -12,7 +12,7 @@
           @click.self="closeModal">
           <div class="ao-modal__content">
             <div :class="computedHeaderClass">
-              <h2>{{ headerText }}</h2>
+              <h2 class="ao-modal__header-text">{{ headerText }}</h2>
             </div>
             <div
               v-if="hasSlot('modal-toolbar')"
@@ -43,8 +43,6 @@ import { filterClasses } from './utils/component_utilities.js'
 
 export default {
   props: {
-    // availible sizes include: 'sm', 'md', 'lg' pertaining to small medium large bootstrap classes
-
     headerText: {
       type: String,
       required: true,
@@ -53,7 +51,10 @@ export default {
 
     size: {
       type: String,
-      default: 'md'
+      default: 'medium',
+      validator: function (value) {
+        return ['small', 'medium', 'large'].indexOf(value) !== -1
+      }
     },
 
     destructive: {
@@ -78,8 +79,10 @@ export default {
     },
 
     computedModalSize () {
-      // computes sizes into scss classes pertaining to size eg. md -> .ao-modal--md
-      return `ao-modal--${this.size}`
+      // computes sizes into scss classes pertaining to size eg. small -> .ao-modal--small
+      if (this.size) {
+        return `ao-modal--${this.size}`
+      }
     }
   },
 
@@ -107,6 +110,8 @@ export default {
   padding-top: 2em;
   z-index: $zindex-modal;
   height: 100%;
+  padding-left: $spacer;
+  padding-right: $spacer;
 
   &:focus {
     outline: 0;
@@ -129,7 +134,7 @@ export default {
     }
   }
 
-  &__header /deep/ div > h2 {
+  &__header-text {
     margin: 0;
     line-height: $line-height-base;
     font-size: $font-size-lg;
@@ -142,18 +147,10 @@ export default {
     border-radius: $border-radius-base;
     box-shadow: $shadow-dramatic;
     transition: all $transition-base;
-  }
 
-  &__toolbar {
-    padding: $spacer;
-    display: flex;
-    justify-content: flex-end;
-    border-bottom: 1px solid $ui-border-color-base;
-
-    & > /deep/ * {
-      padding-left: $spacer;
-      margin-bottom: 0;
-    }
+    margin-left: auto;
+    margin-right: auto;
+    width: 100%;
   }
 
   &__body {
@@ -167,10 +164,16 @@ export default {
     border-top: 1px solid $color-gray-60;
   }
 
-  &--md &__content {
-    max-width: 40%;
-    margin-left: auto;
-    margin-right: auto;
+  &--large &__content {
+    max-width: 800px;
+  }
+
+  &--medium &__content {
+    max-width: 600px;
+  }
+
+  &--small &__content {
+    max-width: 400px;
   }
 }
 

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -391,7 +391,6 @@
 
       <ao-modal
         v-if="showModal"
-        :size="'md'"
         :header-text="'I am the modal title'"
         @modalClose="toggleModal">
         <ao-input

--- a/tests/unit/AoModal.spec.js
+++ b/tests/unit/AoModal.spec.js
@@ -10,29 +10,40 @@ describe('Modal', () => {
     })
     expect(modal.text()).toBe('test')
     expect(modal.classes()).toContain('ao-modal-mask') // will need to change
-    expect(modal.contains('.ao-modal--md')).toBe(true)
+    expect(modal.contains('.ao-modal--medium')).toBe(true)
   })
 
   it('small size', () => {
     const modal = mount(Modal, {
       propsData: {
         headerText: 'test0',
-        size: 'sm'
+        size: 'small'
       }
     })
     expect(modal.text()).toBe('test0')
-    expect(modal.contains('.ao-modal--sm')).toBe(true)
+    expect(modal.contains('.ao-modal--small')).toBe(true)
+  })
+
+  it('medium size', () => {
+    const modal = mount(Modal, {
+      propsData: {
+        headerText: 'test1',
+        size: 'medium'
+      }
+    })
+    expect(modal.text()).toBe('test1')
+    expect(modal.contains('.ao-modal--medium')).toBe(true)
   })
 
   it('large size', () => {
     const modal = mount(Modal, {
       propsData: {
         headerText: 'test1',
-        size: 'lg'
+        size: 'large'
       }
     })
     expect(modal.text()).toBe('test1')
-    expect(modal.contains('.ao-modal--lg')).toBe(true)
+    expect(modal.contains('.ao-modal--large')).toBe(true)
   })
 
   it('destructive', () => {


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/126
also fixes https://github.com/AmpleOrganics/Blaze.vue/issues/113

# Description

- You can pass in `small` or `large` to change the size of the modal
- Responsive! Will not exceed width of the screen
- Snuck in a fix to the header style

# To Do

Documentation
Tests n stuff?
Yell at you if you pass in anything but `small` or `large`?
