### PR TITLE
Create new size prop for inputs, works for small only

### DIFF
--- a/src/assets/styles/mixins/shared-input-styles.scss
+++ b/src/assets/styles/mixins/shared-input-styles.scss
@@ -40,6 +40,11 @@
         box-shadow: $input-focus-shadow-error;
       }
     }
+    &--small {
+      height: $input-height-sm;
+      padding: $spacer-micro;
+      font-size: $font-size-sm;
+    }
   }
   .ao-input-group {
     display: table;

--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -5,7 +5,7 @@
       :for="name">{{ label }}</label>
     <div :class="{ 'ao-input-group': hasInputGroup }">
       <input
-        :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
+        :class="['ao-form-control', {'ao-form-control--invalid': invalid }, computedSize]"
         :type="type"
         :placeholder="placeholder"
         :name="name"
@@ -28,6 +28,8 @@
 </template>
 
 <script>
+import { filterClasses } from './utils/component_utilities.js'
+
 export default {
   props: {
     type: {
@@ -92,6 +94,14 @@ export default {
     invalid: {
       type: Boolean,
       default: false
+    },
+
+    size: {
+      type: String,
+      default: null,
+      validator: function (size) {
+        return [null, 'small'].includes(size)
+      }
     }
   },
 
@@ -106,6 +116,13 @@ export default {
 
     hasAddOn () {
       return this.addOn
+    },
+
+    computedSize () {
+      const activeClasses = {
+        'ao-form-control--small': this.size === 'small'
+      }
+      return filterClasses(activeClasses)
     }
   },
 

--- a/src/components/AoSelect.vue
+++ b/src/components/AoSelect.vue
@@ -8,7 +8,7 @@
     <div>
       <select
         :value="selected"
-        :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
+        :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control', computedSize]"
         :disabled="disabled"
         @change="updateInput">
         <option
@@ -23,6 +23,8 @@
 </template>
 
 <script>
+import { filterClasses } from './utils/component_utilities.js'
+
 export default {
   props: {
     value: {
@@ -53,12 +55,29 @@ export default {
     placeholder: {
       type: String,
       default: null
+    },
+
+    size: {
+      type: String,
+      default: null,
+      validator: function (size) {
+        return [null, 'small'].includes(size)
+      }
     }
   },
 
   data () {
     return {
       selected: null
+    }
+  },
+
+  computed: {
+    computedSize () {
+      const activeClasses = {
+        'ao-form-control--small': this.size === 'small'
+      }
+      return filterClasses(activeClasses)
     }
   },
 

--- a/tests/unit/AoInput.spec.js
+++ b/tests/unit/AoInput.spec.js
@@ -2,39 +2,49 @@ import { mount } from '@vue/test-utils'
 import Input from '@/components/AoInput.vue'
 
 describe('Input', () => {
+  const getFormControlElement = (wrapper) => wrapper.find('.ao-form-control')
+
   it('create', () => {
     const input = mount(Input, {
       propsData: {
-        type: 'text',
-        label: 'test'
+        label: 'label'
       }
     })
-    expect(input.text()).toBe('test')
+    expect(input.text()).toBe('label')
     expect(input.classes()).toContain('ao-form-group')
   })
 
   it('iconClass', () => {
     const input = mount(Input, {
       propsData: {
-        type: 'text',
-        label: 'test0',
+        label: 'label',
         iconClass: 'custom-glyph-clients'
       }
     })
-    expect(input.text()).toBe('test0')
     expect(input.contains('.custom-glyph-clients')).toBe(true)
   })
 
-  it('id invalid', () => {
+  it('invalid', () => {
     const input = mount(Input, {
       propsData: {
-        type: 'text',
-        label: 'test1',
-        invalid: true
+        label: 'label'
       }
     })
-    expect(input.text()).toBe('test1')
-    expect(input.contains('.ao-form-control--invalid')).toBe(true)
+    expect(getFormControlElement(input).classes().includes('.ao-form-control--invalid')).toBe(false)
+
+    input.setProps({ invalid: true })
+    expect(getFormControlElement(input).classes()).toContain('ao-form-control--invalid')
+  })
+
+  it('size', () => {
+    const input = mount(Input, {
+      propsData: {
+        label: 'label',
+        size: 'small'
+      }
+    })
+
+    expect(getFormControlElement(input).classes()).toContain('ao-form-control--small')
   })
 
   it('emit', () => {

--- a/tests/unit/AoSelect.spec.js
+++ b/tests/unit/AoSelect.spec.js
@@ -5,21 +5,21 @@ describe('Select', () => {
   it('create', () => {
     const select = mount(Select, {
       propsData: {
-        label: 'test'
+        label: 'label'
       }
     })
-    expect(select.text()).toBe('test')
+    expect(select.text()).toBe('label')
     expect(select.classes()).toContain('ao-form-group')
   })
 
   it('disabled', () => {
     const select = mount(Select, {
       propsData: {
-        label: 'test0',
+        label: 'label',
         disabled: true
       }
     })
-    expect(select.text()).toBe('test0')
+    expect(select.text()).toBe('label')
     expect(select.find('.ao-form-control').attributes().disabled).toBe('disabled')
   })
 
@@ -40,12 +40,23 @@ describe('Select', () => {
   it('has a placeholder', () => {
     const select = mount(Select, {
       propsData: {
-        label: 'test0',
+        label: 'label',
         placeholder: 'Select One'
       }
     })
 
     expect(select.findAll('option').at(0).element.value).toBe('')
     expect(select.findAll('option').at(0).html()).toContain('Select One')
+  })
+
+  it('size', () => {
+    const select = mount(Select, {
+      propsData: {
+        label: 'label',
+        size: 'small'
+      }
+    })
+
+    expect(select.find('.ao-form-control').classes()).toContain('ao-form-control--small')
   })
 })


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/71
also https://github.com/AmpleOrganics/Blaze.vue/pull/161

# Description

Created a size prop for inputs and selects, and when you pass `small` in it will make those elements smaller. This is mainly motivated by a need for smaller inputs in tables.

# To Do
- Tests
- Yell at you if the size is not an acceptable parameter