### PR TITLE
Create tooltip component

### DIFF
--- a/docs/components/Tooltip.js
+++ b/docs/components/Tooltip.js
@@ -1,0 +1,16 @@
+export default {
+  header: 'Tooltip',
+  description: 'This is a customizable tooltip component.',
+  snippet:
+        `<ao-tooltip
+  position="bottom"
+  text="Tooltip text goes here"
+  multiline>
+  <ao-button primary>Hover over me</ao-button>
+</ao-tooltip>`,
+  apiRows: [
+    { name: 'position', type: 'String (bottom, left, top, right)', default: 'bottom', description: 'Shows tooltip at selected position.' },
+    { name: 'text', type: 'String', default: 'null', description: 'Text for tool tip.' },
+    { name: 'multiline', type: 'Boolean', default: 'false', description: 'Configure tooltip to be single line or multiline.' }
+  ]
+}

--- a/docs/components/Tooltip.vue
+++ b/docs/components/Tooltip.vue
@@ -1,0 +1,79 @@
+<template>
+  <Layout>
+    <template slot="description">
+      <span v-html="description"/>
+    </template>
+
+    <div slot="example">
+      <div class="component-example component-example__tooltip">
+        <ao-tooltip
+          :position="selectedPosition"
+          :text="tooltipText"
+          :multiline="tooltipMultiline">
+          <ao-button primary>Hover over me</ao-button>
+        </ao-tooltip>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="tooltipText"
+            :type="'text'"
+            :label="'Tooltip Text'"
+          />
+        </div>
+        <div class="component-controls__group">
+          <ao-select
+            v-model="selectedPosition"
+            label="Position">
+            <option
+              v-for="prop in tooltipPositions"
+              :value="prop.value"
+              :key="prop.name">
+              {{ prop.name }}
+            </option>
+          </ao-select>
+        </div>
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="tooltipMultiline"
+            :checkbox-label="'Multiline'"
+            :checkbox-value="true"
+          />
+        </div>
+      </div>
+    </div>
+    <template slot="snippet">{{ snippet }}</template>
+    <template slot="api">
+      <ApiTable
+        :rows="apiRows"
+      />
+    </template>
+  </Layout>
+</template>
+
+<script>
+import Layout from '../layout/Layout'
+import ApiTable from '../helpers/ApiTable'
+import TooltipDocumentation from './Tooltip'
+
+export default {
+  components: {
+    Layout,
+    ApiTable
+  },
+  data () {
+    return {
+      ...TooltipDocumentation,
+      tooltipText: 'Tooltip text goes here',
+      tooltipMultiline: true,
+      tooltipPositions: [
+        { value: 'bottom', name: 'bottom' },
+        { value: 'left', name: 'left' },
+        { value: 'top', name: 'top' },
+        { value: 'right', name: 'right' }
+      ],
+      selectedPosition: 'bottom'
+    }
+  }
+}
+</script>

--- a/src/assets/styles/mixins/shared-input-styles.scss
+++ b/src/assets/styles/mixins/shared-input-styles.scss
@@ -84,4 +84,10 @@
       font-weight: $font-weight-bold;
     }
   }
+
+  .ao-form-group__label {
+    & .ao-tooltip {
+      margin-left: $spacer-micro;
+    }
+  }
 }

--- a/src/assets/styles/settings/_variables.scss
+++ b/src/assets/styles/settings/_variables.scss
@@ -27,7 +27,8 @@ $color-destructive:           $color-red;
 $color-gray-10:               #474a4c;
 $color-gray-20:               #585d60;
 $color-gray-30:               #818a91;
-$color-gray-50:               #ccc;
+$color-gray-40:               #aaaaaa;
+$color-gray-50:               #cccccc;
 $color-gray-60:               #dcdedf;
 $color-gray-80:               #ebecef;
 $color-gray-90:               #f7f7f9;
@@ -79,6 +80,7 @@ $zindex-modal-backdrop:       1030;
 $zindex-modal:                1031;
 $zindex-alert:                1040;
 $zindex-spinner:              1050;
+$zindex-tooltip:              1060;
 
 $header-toolbar-height:       60px;
 

--- a/src/blaze-plugin.js
+++ b/src/blaze-plugin.js
@@ -21,6 +21,7 @@ import AoSpinner from './components/AoSpinner.vue'
 import AoTable from './components/AoTable.vue'
 import AoTextArea from './components/AoTextArea.vue'
 import AoTextStyle from './components/AoTextStyle.vue'
+import AoTooltip from './components/AoTooltip.vue'
 import ClickOutside from './directives/click-outside.js'
 
 const Blaze = {
@@ -47,6 +48,7 @@ const Blaze = {
     Vue.component('AoTable', AoTable)
     Vue.component('AoTextArea', AoTextArea)
     Vue.component('AoTextStyle', AoTextStyle)
+    Vue.component('AoTooltip', AoTooltip)
     Vue.directive('ClickOutside', ClickOutside)
   }
 }

--- a/src/components/AoFileUpload.vue
+++ b/src/components/AoFileUpload.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="ao-form-group">
-    <label v-show="showLabel">
-      {{ label }}
-    </label>
+    <div
+      v-show="showLabel"
+      class="ao-form-group__label">
+      <label
+        :for="name">{{ label }}</label>
+      <slot name="fileUploadLabelTooltip"/>
+    </div>
     <input
       :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
       :name="name"

--- a/src/components/AoInfoPair.vue
+++ b/src/components/AoInfoPair.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="ao-info-pair">
-    <h4 class="ao-info-pair__label">{{ label }}</h4>
+    <div class="ao-info-pair__label">
+      <h4 class="ao-info-pair__label-text">
+        {{ label }}
+      </h4>
+      <slot name="tooltip"/>
+    </div>
     <div class="ao-info-pair__value">
       <slot/>
     </div>
@@ -23,13 +28,20 @@ export default {
 .ao-info-pair {
   margin-bottom: $spacer;
 
-  &__label {
+  &__label-text {
     margin-bottom: 0;
     margin-top: 0;
     font-weight: $font-weight-bold;
     font-size: $font-size-xs;
     text-transform: uppercase;
     color: $color-gray-30;
+    display: inline-block;
+  }
+
+  &__label .ao-tooltip {
+    display: inline-block;
+    margin-left: $spacer-micro;
+    font-size: $font-size-sm;
   }
 }
 

--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="ao-form-group">
-    <label
+    <div
       v-show="showLabel"
-      :for="name">{{ label }}</label>
+      class="ao-form-group__label">
+      <label
+        :for="name">{{ label }}</label>
+      <slot name="tooltip"/>
+    </div>
     <div :class="{ 'ao-input-group': hasInputGroup }">
       <input
         :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"

--- a/src/components/AoSelect.vue
+++ b/src/components/AoSelect.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="ao-form-group">
-    <label
+    <div
       v-show="showLabel"
-      :disabled="disabled">
-      {{ label }}
-    </label>
-    <div>
+      class="ao-form-group__label">
+      <label
+        :for="name">{{ label }}</label>
+      <slot name="tooltip"/>
+    </div>
+    <div :class="{ 'ao-input-group': hasInputGroup }">
       <select
         v-model="selected"
         :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"

--- a/src/components/AoTextArea.vue
+++ b/src/components/AoTextArea.vue
@@ -1,9 +1,13 @@
 <template>
   <!-- investigate min max length -->
   <div class="ao-form-group">
-    <label
+    <div
       v-show="showLabel"
-      :for="name">{{ label }}</label>
+      class="ao-form-group__label">
+      <label
+        :for="name">{{ label }}</label>
+      <slot name="tooltip"/>
+    </div>
     <textarea
       :class="{'ao-form-control--invalid': invalid }"
       :value="value"

--- a/src/components/AoTooltip.vue
+++ b/src/components/AoTooltip.vue
@@ -1,0 +1,172 @@
+<template>
+  <div
+    :class="[computedClasses, `ao-tooltip--${this.position}`]">
+    <slot>
+      <i class="ao-tooltip__default-icon glyphicon glyphicon-info-sign"/>
+    </slot>
+    <div class="ao-tooltip__tip-container">
+      <span class="ao-tooltip__text">{{ text }}</span>
+      <div class="ao-tooltip__triangle"/>
+    </div>
+  </div>
+</template>
+
+<script>
+import { filterClasses } from './utils/component_utilities.js'
+
+export default {
+  props: {
+    text: {
+      type: String,
+      required: true,
+      default: null
+    },
+
+    position: {
+      type: String,
+      required: false,
+      default: 'bottom'
+    },
+
+    multiline: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+
+  computed: {
+    computedClasses () {
+      const activeClasses = {
+        'ao-tooltip': true,
+        'ao-tooltip--multiline': this.multiline
+      }
+      return filterClasses(activeClasses)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+
+$tooltip-distance: $spacer-micro; /* Defining a consistent distance from the object; */
+$tooltip-background-color: $color-gray-10;
+$tooltip-transition: opacity .2s ease-in-out;
+
+.ao-tooltip {
+  position: relative;
+  display: inline-block;
+
+  &__tip-container {
+    position: absolute;
+    width: 0;
+    height: 0;
+    z-index: $zindex-tooltip;
+    overflow: hidden;
+  }
+
+  &__text {
+    visibility: hidden;
+    position: absolute;
+    background: $tooltip-background-color;
+    font-size: $font-size-sm;
+    color: $color-white;
+    opacity: 0;
+    padding: $spacer-micro $spacer-micro*2;
+    border-radius: $border-radius-base;
+    white-space: nowrap;
+    transition: $tooltip-transition;
+  }
+
+  &__triangle {
+    visibility: hidden;
+    position: absolute;
+    opacity: 0;
+    transition: $tooltip-transition;
+    border-style: solid;
+    border-width: $tooltip-distance $tooltip-distance 0 $tooltip-distance ;
+    border-color: $tooltip-background-color transparent transparent transparent;
+  }
+
+  &__default-icon {
+    color: $color-gray-40;
+    font-size: $font-size-sm;
+  }
+
+  &--multiline &__text {
+    white-space: pre-wrap;
+    width: 200px;
+  }
+
+  &--left &__tip-container {
+    left: 0;
+    top: 50%;
+
+    .ao-tooltip__text {
+      right: 0;
+      transform: translateY(-50%);
+      margin-right: $tooltip-distance;
+    }
+
+    .ao-tooltip__triangle {
+      right: 0;
+      transform: rotate(-90deg) translate(($tooltip-distance/2), 50%);
+    }
+  }
+
+  &--right &__tip-container {
+    right: 0;
+    top: 50%;
+
+    .ao-tooltip__text {
+      transform: translateY(-50%);
+      margin-left: $tooltip-distance;
+    }
+
+    .ao-tooltip__triangle {
+      transform: rotate(90deg) translate(-($tooltip-distance/2), 50%);
+    }
+  }
+
+  &--top &__tip-container {
+    top: 0;
+    right: 50%;
+
+    .ao-tooltip__text {
+      bottom: 0;
+      transform: translateX(-50%);
+      margin-bottom: $tooltip-distance;
+    }
+
+    .ao-tooltip__triangle {
+      bottom: 0;
+      transform: translateX(-50%);
+    }
+  }
+
+  &--bottom &__tip-container {
+    bottom: 0;
+    right: 50%;
+
+    .ao-tooltip__text {
+      transform: translateX(-50%);
+      margin-top: $tooltip-distance;
+    }
+
+    .ao-tooltip__triangle {
+      top: 0;
+      transform: rotate(180deg) translateX(50%);
+    }
+  }
+
+  &:hover &__tip-container {
+    overflow: visible;
+  }
+
+  &:hover &__text,
+  &:hover &__triangle {
+    visibility: visible;
+    opacity: 1;
+  }
+}
+</style>

--- a/src/router.js
+++ b/src/router.js
@@ -23,6 +23,7 @@ import Spinner from '../docs/components/Spinner.vue'
 import Table from '../docs/components/Table.vue'
 import TextArea from '../docs/components/TextArea.vue'
 import TextStyle from '../docs/components/TextStyle.vue'
+import Tooltip from '../docs/components/Tooltip.vue'
 
 Vue.use(Router)
 
@@ -58,6 +59,7 @@ export default new Router({
     { name: 'spinner', path: '/spinner', component: Spinner, meta: { title: 'Spinner' } },
     { name: 'table', path: '/table', component: Table, meta: { title: 'Table' } },
     { name: 'textarea', path: '/textarea', component: TextArea, meta: { title: 'Text Area' } },
-    { name: 'textstyle', path: '/textstyle', component: TextStyle, meta: { title: 'Text Style' } }
+    { name: 'textstyle', path: '/textstyle', component: TextStyle, meta: { title: 'Text Style' } },
+    { name: 'tooltip', path: '/tooltip', component: Tooltip, meta: { title: 'Tooltip' } }
   ]
 })

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -54,6 +54,41 @@
         <ao-heading
           card-section-heading
           text="Form Examples"/>
+        <div style="text-align: center;">
+          <p>
+            <ao-tooltip
+              position="top"
+              text="Tooltip with some really long text">
+              <ao-button primary>Hover Me!</ao-button>
+            </ao-tooltip>
+          </p>
+          <p>
+            <ao-tooltip
+              position="bottom"
+              text="Tooltip with some really long text, fixed width for things that are kinda long"
+              multiline>
+              <ao-button primary>Multiline</ao-button>
+            </ao-tooltip>
+          </p>
+          <p>
+            <ao-tooltip
+              position="left"
+              text="Tooltip with some really long text">
+              <ao-button primary>Hover Me!</ao-button>
+            </ao-tooltip>
+          </p>
+          <p>
+            <ao-tooltip
+              position="right"
+              text="Tooltip with some really long text">
+              <ao-button primary>Hover Me!</ao-button>
+            </ao-tooltip>
+          </p>
+          <p>
+            <ao-tooltip
+              text="Default icon, default position"/>
+          </p>
+        </div>
         <p>
           <ao-text-style
             error

--- a/tests/unit/AoTooltip.spec.js
+++ b/tests/unit/AoTooltip.spec.js
@@ -1,0 +1,35 @@
+import { mount } from '@vue/test-utils'
+import Tooltip from '@/components/AoTooltip.vue'
+
+describe('AoTooltip', () => {
+  it('create', () => {
+    const tooltip = mount(Tooltip, {
+      propsData: {
+        text: 'tooltip'
+      }
+    })
+    expect(tooltip.classes()).toContain('ao-tooltip')
+    expect(tooltip.classes()).toContain('ao-tooltip--bottom')
+    expect(tooltip.find('.ao-tooltip__text').text()).toBe('tooltip')
+  })
+
+  it('position', () => {
+    const tooltip = mount(Tooltip, {
+      propsData: {
+        text: 'tooltip',
+        position: 'top'
+      }
+    })
+    expect(tooltip.classes()).toContain('ao-tooltip--top')
+  })
+
+  it('multiline', () => {
+    const tooltip = mount(Tooltip, {
+      propsData: {
+        text: 'tooltip',
+        multiline: true
+      }
+    })
+    expect(tooltip.classes()).toContain('ao-tooltip--multiline')
+  })
+})


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/2

# Description

This is a tooltip component.
You wrap it around anything. If you don't pass anything into it, it will be just a cute little info icon.
By default the position is below the element. This can be overridden by passing in a `position` string - top, left, or right (or bottom, if you want)
If the tooltip is long, you can add the `multiline` prop, which gives it a fixed width and lets the text wrap.

I also added a tooltip slot to various other components so that we can add tooltips to them.

# To Do
- Tests n stuff
- Rules for usage
