### PR TITLE
breadcrumb seprator logic improved

### DIFF
--- a/docs/.vuepress/components/AoBreadcrumbs.vue
+++ b/docs/.vuepress/components/AoBreadcrumbs.vue
@@ -9,13 +9,16 @@
           class="ao-breadcrumbs__crumb">
           {{ name }}
         </router-link>
-        <span class="ao-breadcrumbs__crumb-separator">{{ separator }}</span>
       </span>
-      <span v-else>
-        <span
-          class="ao-breadcrumbs__crumb ao-breadcrumbs__crumb--active">
-          {{ name }}
-        </span>
+      <span
+        v-if="active"
+        class="ao-breadcrumbs__crumb ao-breadcrumbs__crumb--active">
+        {{ name }}
+      </span>
+      <span
+        v-if="ifSeparator(index)"
+        class="ao-breadcrumbs__crumb-separator">
+        {{ separator }}
       </span>
     </span>
   </div>
@@ -32,6 +35,12 @@ export default {
     paths: {
       type: Array,
       required: true
+    }
+  },
+
+  methods: {
+    ifSeparator (index) {
+      return index + 1 !== this.paths.length
     }
   }
 }

--- a/src/components/AoBreadcrumbs.vue
+++ b/src/components/AoBreadcrumbs.vue
@@ -9,13 +9,16 @@
           class="ao-breadcrumbs__crumb">
           {{ name }}
         </router-link>
-        <span class="ao-breadcrumbs__crumb-separator">{{ separator }}</span>
       </span>
-      <span v-else>
-        <span
-          class="ao-breadcrumbs__crumb ao-breadcrumbs__crumb--active">
-          {{ name }}
-        </span>
+      <span
+        v-if="active"
+        class="ao-breadcrumbs__crumb ao-breadcrumbs__crumb--active">
+        {{ name }}
+      </span>
+      <span
+        v-if="ifSeparator(index)"
+        class="ao-breadcrumbs__crumb-separator">
+        {{ separator }}
       </span>
     </span>
   </div>
@@ -32,6 +35,12 @@ export default {
     paths: {
       type: Array,
       required: true
+    }
+  },
+
+  methods: {
+    ifSeparator (index) {
+      return index + 1 !== this.paths.length
     }
   }
 }


### PR DESCRIPTION
# Description

separator for breadcrumbs was based on active and not active routes instead of route lengths

this is now fixed, as a result the separator is now inline with active and non active routes