### PR TITLE
Improve breadcrumb styles

### DIFF
--- a/docs/.vuepress/components/AoBreadcrumbs.vue
+++ b/docs/.vuepress/components/AoBreadcrumbs.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="ao-breadcrumbs">
-    <span
+    <div
       v-for="({ name, path, active}, index) in paths"
-      :key="index">
-      <span v-if="!active">
-        <router-link
-          :to="path"
-          class="ao-breadcrumbs__crumb">
-          {{ name }}
-        </router-link>
-      </span>
+      :key="index"
+      class="ao-breadcrumbs__crumb-group">
+      <router-link
+        v-if="!active"
+        :to="path"
+        class="ao-breadcrumbs__crumb">
+        {{ name }}
+      </router-link>
       <span
         v-if="active"
         class="ao-breadcrumbs__crumb ao-breadcrumbs__crumb--active">
@@ -20,7 +20,7 @@
         class="ao-breadcrumbs__crumb-separator">
         {{ separator }}
       </span>
-    </span>
+    </div>
   </div>
 </template>
 
@@ -51,24 +51,31 @@ export default {
 @import '../_variables.scss';
 .ao-breadcrumbs {
   margin-bottom: $spacer;
+  display: flex;
+
+  &__crumb-group {
+    display: flex;
+  }
 
   &__crumb {
-    text-transform: uppercase;
-    color: $color-gray-30;
     text-decoration: none;
     font-size: $font-size-xs;
+    text-transform: uppercase;
 
-    &:not(&--active) {
-      font-weight: $font-weight-bold;
+    &--active {
+      color: $color-gray-30;
     }
 
     &:not(&--active):hover {
-      color: $color-gray-20;
+      text-decoration: underline;
     }
   }
 
   &__crumb-separator {
     font-size: $font-size-xs;
+    margin-left: $spacer-micro;
+    margin-right: $spacer-micro;
+    color: $color-gray-30;
   }
 }
 </style>

--- a/src/components/AoBreadcrumbs.vue
+++ b/src/components/AoBreadcrumbs.vue
@@ -4,26 +4,22 @@
       v-for="({ name, path, active}, index) in paths"
       :key="index"
       class="ao-breadcrumbs__crumb-group">
-      <div
-        v-if="!active">
-        <router-link
-          :to="path"
-          class="ao-breadcrumbs__crumb">
-          {{ name }}
-        </router-link>
-      </div>
-      <div
-        v-if="active">
-        <span class="ao-breadcrumbs__crumb ao-breadcrumbs__crumb--active">
-          {{ name }}
-        </span>
-      </div>
-      <div
-        v-if="ifSeparator(index)">
-        <span class="ao-breadcrumbs__crumb-separator">
-          {{ separator }}
-        </span>
-      </div>
+      <router-link
+        v-if="!active"
+        :to="path"
+        class="ao-breadcrumbs__crumb">
+        {{ name }}
+      </router-link>
+      <span
+        v-if="active"
+        class="ao-breadcrumbs__crumb ao-breadcrumbs__crumb--active">
+        {{ name }}
+      </span>
+      <span
+        v-if="ifSeparator(index)"
+        class="ao-breadcrumbs__crumb-separator">
+        {{ separator }}
+      </span>
     </div>
   </div>
 </template>

--- a/tests/unit/AoBreadcrumbs.spec.js
+++ b/tests/unit/AoBreadcrumbs.spec.js
@@ -16,9 +16,9 @@ describe('Breadcrumb', () => {
       }
     })
     expect(breadcrumb.findAll('a').length).toBe(2)
-    expect(breadcrumb.findAll('span').at(6).text()).toBe('Current')
-    expect(breadcrumb.findAll('span').at(5).text()).toBe('/')
-    expect(breadcrumb.findAll('span').at(3).text()).toBe('/')
+    expect(breadcrumb.findAll('span').at(2).text()).toBe('Current')
+    expect(breadcrumb.findAll('span').at(1).text()).toBe('/')
+    expect(breadcrumb.findAll('span').at(0).text()).toBe('/')
 
     expect(breadcrumb.find('.ao-breadcrumbs__crumb--active').exists()).toBe(true)
     expect(breadcrumb.find('.ao-breadcrumbs__crumb--active').text()).toBe('Current')
@@ -38,7 +38,7 @@ describe('Breadcrumb', () => {
         ]
       }
     })
-    expect(breadcrumb.findAll('span').at(5).text()).toBe('>')
-    expect(breadcrumb.findAll('span').at(3).text()).toBe('>')
+    expect(breadcrumb.findAll('span').at(1).text()).toBe('>')
+    expect(breadcrumb.findAll('span').at(0).text()).toBe('>')
   })
 })


### PR DESCRIPTION
# Link to Github Issue

N/A

# Description

- Using `div`s instead of `span`s because they're more appropriate IMO
- Links are now primary color to fit with conventions for clickability
- Flexboxing my way through avoiding annoying whitespace issues
- lint fixes