### PR TITLE
112 caution modal text should be dark

### DIFF
--- a/docs/.vuepress/components/AoModal.vue
+++ b/docs/.vuepress/components/AoModal.vue
@@ -115,6 +115,7 @@ export default {
     }
 
     &--caution {
+      color: $color-dark;
       background-color: $color-caution;
     }
   }

--- a/src/components/AoModal.vue
+++ b/src/components/AoModal.vue
@@ -114,6 +114,7 @@ export default {
     }
 
     &--caution {
+      color: $color-dark;
       background-color: $color-caution;
     }
   }


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/112

# Description

caution modal text should be dark