### PR TITLE
189 - Add prop for passing in instruction text

### DIFF
--- a/docs/components/Button.js
+++ b/docs/components/Button.js
@@ -9,11 +9,11 @@ export default {
     { name: 'primary', type: 'Boolean', default: 'false', description: 'Adds a class to indicate a primary action eg. submission, confirmation.' },
     { name: 'destructive', type: 'Boolean', default: 'false', description: 'Adds a class to indicate a destructive action eg. deletion, permanent irreversible action.' },
     { name: 'caution', type: 'Boolean', default: 'false', description: 'Adds a class to indicate a cautious action eg. reversible powerful change.' },
-    { name: 'subtle', type: 'Boolean', default: 'false', description: 'Displays a more subtle version of the default button' },
-    { name: 'small', type: 'Boolean', default: 'false', description: 'Displays a small sized button' },
-    { name: 'large', type: 'Boolean', default: 'false', description: 'Displays a large sized button' },
-    { name: 'jumbo', type: 'Boolean', default: 'false', description: 'Displays a jumbo sized button' },
-    { name: 'naked', type: 'Boolean', default: 'false', description: 'Displays a style that lacks the visual properties of a button' },
-    { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables the button' }
+    { name: 'subtle', type: 'Boolean', default: 'false', description: 'Displays a more subtle version of the default button.' },
+    { name: 'small', type: 'Boolean', default: 'false', description: 'Displays a small sized button.' },
+    { name: 'large', type: 'Boolean', default: 'false', description: 'Displays a large sized button.' },
+    { name: 'jumbo', type: 'Boolean', default: 'false', description: 'Displays a jumbo sized button.' },
+    { name: 'naked', type: 'Boolean', default: 'false', description: 'Displays a style that lacks the visual properties of a button.' },
+    { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables the button.' }
   ]
 }

--- a/docs/components/FileUpload.js
+++ b/docs/components/FileUpload.js
@@ -7,10 +7,11 @@ export default {
   :name="'File'"
 />`,
   apiRows: [
-    { name: 'label', type: 'String, required', default: '-', description: 'Displays a text label above the button to describe the action' },
-    { name: 'name', type: 'String, required', default: '-', description: 'Specifies the name of the &lt;label&gt; element' },
-    { name: 'showLabel', type: 'Boolean', default: 'true', description: 'Hide or unhide the text label' },
-    { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component' },
-    { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry' }
+    { name: 'label', type: 'String, required', default: '-', description: 'Displays a text label above the button to describe the action.' },
+    { name: 'name', type: 'String, required', default: '-', description: 'Specifies the name of the &lt;label&gt; element.' },
+    { name: 'showLabel', type: 'Boolean', default: 'true', description: 'Hide or unhide the text label.' },
+    { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' },
+    { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
+    { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' }
   ]
 }

--- a/docs/components/Input.js
+++ b/docs/components/Input.js
@@ -33,6 +33,7 @@ export default {
     { name: 'addOn', type: 'String', default: 'null', description: 'Appends text to the input.' },
     { name: 'step', type: 'Number', default: '1', description: 'Valid for input type "number". Defines the amount of changes per click.' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' },
+    { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
     { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' }
   ]
 }

--- a/docs/components/Select.js
+++ b/docs/components/Select.js
@@ -28,9 +28,9 @@ data () {
     { name: 'value', type: 'String', default: 'null', description: 'This prop defines the selected value.' },
     { name: 'label', type: 'String, required', default: 'null', description: 'This prop defines the label of the select.' },
     { name: 'showLabel', type: 'Boolean', default: 'true', description: 'This prop defines if the select label will be shown or not.' },
+    { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
     { name: 'invalid', type: 'Boolean', default: 'false', description: 'This prop defines the select to be invalid.' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'This prop disables the select.' },
     { name: 'placeholder', type: 'String', default: 'null', description: 'This prop defines the placeholder of the select.' }
-
   ]
 }

--- a/docs/components/TextArea.js
+++ b/docs/components/TextArea.js
@@ -18,6 +18,7 @@ export default {
     { name: 'minLength', type: 'Number', default: '0', description: 'Defines the minimum length of characters within the text area.' },
     { name: 'rows', type: 'Number', default: '5', description: 'Defines the number of rows of the text area.' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' },
+    { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
     { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' }
   ]
 }

--- a/src/assets/styles/mixins/shared-input-styles.scss
+++ b/src/assets/styles/mixins/shared-input-styles.scss
@@ -95,4 +95,11 @@
       margin-left: $spacer-micro;
     }
   }
+  
+  .ao-form-group__instruction-text {
+    display: block;
+    font-size: $font-size-xs;
+    color: $color-gray-30;
+    margin-top: $spacer-micro;
+  }
 }

--- a/src/components/AoFileUpload.vue
+++ b/src/components/AoFileUpload.vue
@@ -13,6 +13,11 @@
       :disabled="disabled"
       type="file"
       @change="updateFile($event.target.files)">
+    <span
+      v-if="instructionText"
+      class="ao-form-group__instruction-text">
+      {{ instructionText }}
+    </span>
   </div>
 </template>
 
@@ -42,6 +47,11 @@ export default {
     name: {
       type: String,
       required: true
+    },
+
+    instructionText: {
+      type: String,
+      default: null
     }
   },
 

--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -28,6 +28,11 @@
         {{ addOn }}
       </span>
     </div>
+    <span
+      v-if="instructionText"
+      class="ao-form-group__instruction-text">
+      {{ instructionText }}
+    </span>
   </div>
 </template>
 
@@ -106,6 +111,11 @@ export default {
       validator: function (size) {
         return [null, 'small'].includes(size)
       }
+    },
+
+    instructionText: {
+      type: String,
+      default: null
     }
   },
 

--- a/src/components/AoSelect.vue
+++ b/src/components/AoSelect.vue
@@ -21,6 +21,11 @@
         <slot/>
       </select>
     </div>
+    <span
+      v-if="instructionText"
+      class="ao-form-group__instruction-text">
+      {{ instructionText }}
+    </span>
   </div>
 </template>
 
@@ -65,6 +70,11 @@ export default {
       validator: function (size) {
         return [null, 'small'].includes(size)
       }
+    },
+
+    instructionText: {
+      type: String,
+      default: null
     }
   },
 

--- a/src/components/AoTextArea.vue
+++ b/src/components/AoTextArea.vue
@@ -20,6 +20,11 @@
       class="ao-form-control"
       @input="inputEvent($event.target.value)"
     />
+    <span
+      v-if="instructionText"
+      class="ao-form-group__instruction-text">
+      {{ instructionText }}
+    </span>
   </div>
 </template>
 
@@ -74,6 +79,11 @@ export default {
     showLabel: {
       type: Boolean,
       default: true
+    },
+
+    instructionText: {
+      type: String,
+      default: null
     }
   },
 

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -202,7 +202,8 @@
           :type="'number'"
           :label="'Age'"
           v-model="age"
-          :step="5"/>
+          :step="5"
+          instruction-text="This is instruction text for this input."/>
         <p>My age: {{ age }}</p>
 
         <ao-file-upload

--- a/tests/unit/AoFileUpload.spec.js
+++ b/tests/unit/AoFileUpload.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import FileUpload from '@/components/AoFileUpload.vue'
+import instructionText from './helpers/instructionText'
 
 describe('FileUpload', () => {
   it('create', () => {
@@ -47,5 +48,16 @@ describe('FileUpload', () => {
 
     fileUpload.find('.ao-form-control').trigger('change')
     expect(fileUpload.emitted().change).toBeTruthy()
+  })
+
+  it('instruction text', () => {
+    const fileUpload = mount(FileUpload, {
+      propsData: {
+        label: 'test',
+        name: 'test1'
+      }
+    })
+
+    instructionText.assert(fileUpload)
   })
 })

--- a/tests/unit/AoInput.spec.js
+++ b/tests/unit/AoInput.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import Input from '@/components/AoInput.vue'
+import instructionText from './helpers/instructionText'
 
 describe('Input', () => {
   const getFormControlElement = (wrapper) => wrapper.find('.ao-form-control')
@@ -58,5 +59,16 @@ describe('Input', () => {
 
     input.find('.ao-form-control').trigger('input')
     expect(input.emitted().input[0][0]).toBe('value')
+  })
+
+  it('instruction text', () => {
+    const input = mount(Input, {
+      propsData: {
+        type: 'text',
+        label: 'test'
+      }
+    })
+
+    instructionText.assert(input)
   })
 })

--- a/tests/unit/AoSelect.spec.js
+++ b/tests/unit/AoSelect.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import Select from '@/components/AoSelect.vue'
+import instructionText from './helpers/instructionText'
 
 describe('Select', () => {
   it('create', () => {
@@ -58,5 +59,15 @@ describe('Select', () => {
     })
 
     expect(select.find('.ao-form-control').classes()).toContain('ao-form-control--small')
+  })
+
+  it('instruction text', () => {
+    const select = mount(Select, {
+      propsData: {
+        label: 'test'
+      }
+    })
+
+    instructionText.assert(select)
   })
 })

--- a/tests/unit/AoTextArea.spec.js
+++ b/tests/unit/AoTextArea.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import TextArea from '@/components/AoTextArea.vue'
+import instructionText from './helpers/instructionText'
 
 describe('TextArea', () => {
   it('create', () => {
@@ -25,5 +26,11 @@ describe('TextArea', () => {
 
     textArea.find('.ao-form-control').trigger('input')
     expect(textArea.emitted().input[0][0]).toBe('value')
+  })
+
+  it('instruction text', () => {
+    const textArea = mount(TextArea)
+
+    instructionText.assert(textArea)
   })
 })

--- a/tests/unit/helpers/instructionText.js
+++ b/tests/unit/helpers/instructionText.js
@@ -1,0 +1,10 @@
+const instructionSelector = '.ao-form-group__instruction-text'
+
+export default {
+  assert (wrapper) {
+    expect(wrapper.contains(instructionSelector)).toBe(false)
+
+    wrapper.setProps({ instructionText: 'instruction' })
+    expect(wrapper.find(instructionSelector).text()).toBe('instruction')
+  }
+}


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/189

# Description
Added a prop for passing in instructional text that will appear below the input.
Also decreased the margin on input labels.

# Todo
Docs and testing?