### PR TITLE
Fixes/table default empty state

### DIFF
--- a/docs/components/Alert.vue
+++ b/docs/components/Alert.vue
@@ -39,8 +39,8 @@
         <div class="component-controls__group">
           <ao-checkbox
             v-model="showAlert"
-            :checkbox-label="'showAlert'"
             :checkbox-value="true"
+            checkbox-label="showAlert"
           />
         </div>
       </div>

--- a/docs/components/Button.vue
+++ b/docs/components/Button.vue
@@ -51,8 +51,8 @@
         <div class="component-controls__group">
           <ao-checkbox
             v-model="disabled"
-            :checkbox-label="'disabled'"
             :checkbox-value="true"
+            checkbox-label="disabled"
           />
         </div>
       </div>

--- a/docs/components/Checkbox.js
+++ b/docs/components/Checkbox.js
@@ -3,7 +3,7 @@ export default {
   description: 'This is a customizable checkbox component.',
   snippet:
         `<ao-checkbox
-  :checkbox-label="'Label'"
+  checkbox-label="Label"
   :show-label="true"
   :checkbox-value="true"
 />`,

--- a/docs/components/Checkbox.vue
+++ b/docs/components/Checkbox.vue
@@ -9,10 +9,10 @@
 
       <div class="component-example">
         <ao-checkbox
-          :checkbox-label="checkboxLabel"
           :show-label="showLabel"
           :disabled="disabled"
           :checkbox-value="true"
+          checkbox-label="checkboxLabel"
         />
       </div>
       <div class="component-controls">
@@ -26,15 +26,15 @@
         <div class="component-controls__group">
           <ao-checkbox
             v-model="showLabel"
-            :checkbox-label="'showLabel'"
             :checkbox-value="true"
+            checkbox-label="showLabel"
           />
         </div>
         <div class="component-controls__group">
           <ao-checkbox
             v-model="disabled"
-            :checkbox-label="'disabled'"
             :checkbox-value="true"
+            checkbox-label="disabled"
           />
         </div>
       </div>

--- a/docs/components/Dropdown.vue
+++ b/docs/components/Dropdown.vue
@@ -22,8 +22,8 @@
         <div class="component-controls__group">
           <ao-checkbox
             v-model="showDropdown"
-            :checkbox-label="'showDropdown'"
             :checkbox-value="true"
+            checkbox-label="showDropdown"
           />
         </div>
       </div>

--- a/docs/components/FileUpload.vue
+++ b/docs/components/FileUpload.vue
@@ -26,18 +26,18 @@
         <div class="component-controls__group">
           <ao-checkbox
             v-model="showLabel"
-            :checkbox-label="'showLabel'"
             :checkbox-value="true"
+            checkbox-label="showLabel"
           />
           <ao-checkbox
             v-model="disabled"
-            :checkbox-label="'disabled'"
             :checkbox-value="true"
+            checkbox-label="disabled"
           />
           <ao-checkbox
             v-model="invalid"
-            :checkbox-label="'invalid'"
             :checkbox-value="true"
+            checkbox-label="invalid"
           />
         </div>
       </div>

--- a/docs/components/Input.vue
+++ b/docs/components/Input.vue
@@ -47,22 +47,22 @@
       <div class="component-controls__group">
         <ao-checkbox
           v-model="showLabel"
-          :checkbox-label="'showLabel'"
           :checkbox-value="true"
+          checkbox-label="showLabel"
         />
       </div>
       <div class="component-controls__group">
         <ao-checkbox
           v-model="disabled"
-          :checkbox-label="'disabled'"
           :checkbox-value="false"
+          checkbox-label="disabled"
         />
       </div>
       <div class="component-controls__group">
         <ao-checkbox
           v-model="invalid"
-          :checkbox-label="'invalid'"
           :checkbox-value="true"
+          checkbox-label="invalid"
         />
       </div>
       <h3 class="component-sub-example">Number Input Example</h3>

--- a/docs/components/Select.vue
+++ b/docs/components/Select.vue
@@ -41,22 +41,22 @@
         <div class="component-controls__group">
           <ao-checkbox
             v-model="showLabel"
-            :checkbox-label="'showLabel'"
             :checkbox-value="true"
+            checkbox-label="showLabel"
           />
         </div>
         <div class="component-controls__group">
           <ao-checkbox
             v-model="disabled"
-            :checkbox-label="'disabled'"
             :checkbox-value="true"
+            checkbox-label="disabled"
           />
         </div>
         <div class="component-controls__group">
           <ao-checkbox
             v-model="invalid"
-            :checkbox-label="'invalid'"
             :checkbox-value="true"
+            checkbox-label="invalid"
           />
         </div>
       </div>

--- a/docs/components/Table.js
+++ b/docs/components/Table.js
@@ -5,11 +5,14 @@ export default {
         `<ao-table
   :headers="headers"
   :is-clickable="isClickable"
+  :show-no-data-text="showNoDataText"
+  :no-data-text="noDataText"
   :sort-by="sortBy"
   :order="order"
+  class="component-example-table"
   @sortTable="sortTable">
   <tr
-    v-for="user in users"
+    v-for="user in filteredUsers"
     :key="user.id">
     <td>{{ user.id }}</td>
     <td>{{ user.first_name }}</td>
@@ -19,40 +22,49 @@ export default {
 
 data () {
   return {
+    ...TableDocumentation,
     headers: [
-        { field: 'id', title: 'ID', sortable: true },
-        { field: 'first_name', title: 'First Name', sortable: true },
-        { field: 'last_name', title: 'Last Name', sortable: true }
-      ],
-      users: [
-        { 'id': 1, 'first_name': 'Jesse', 'last_name': 'Simmons'},
-        { 'id': 2, 'first_name': 'John', 'last_name': 'Jacobs'},
-        { 'id': 3, 'first_name': 'Tina', 'last_name': 'Gilbert'},
-        { 'id': 4, 'first_name': 'Clarence', 'last_name': 'Flores'},
-        { 'id': 5, 'first_name': 'Anne', 'last_name': 'Lee'},
-        { 'id': 6, 'first_name': 'Rick', 'last_name': 'Potter'},
-        { 'id': 7, 'first_name': 'Harry', 'last_name': 'Sanchez'},
-        { 'id': 8, 'first_name': 'Joy', 'last_name': 'Mann'},
-        { 'id': 9, 'first_name': 'Adam', 'last_name': 'Hansen'},
-        { 'id': 10, 'first_name': 'Marge', 'last_name': 'Grey'}
-      ],
-      sortBy: 'id',
-      order: 'desc',
-      isClickable: false
-  },
-
-  methods: {
-    sortTable (sortBy, order) {
-      this.users = orderBy(this.users, sortBy, order)
-    }
+      { field: 'id', title: 'ID', sortable: true },
+      { field: 'first_name', title: 'First Name', sortable: true },
+      { field: 'last_name', title: 'Last Name', sortable: true }
+    ],
+    users: [
+      { 'id': 1, 'first_name': 'Jesse', 'last_name': 'Simmons' },
+      { 'id': 2, 'first_name': 'John', 'last_name': 'Jacobs' },
+      { 'id': 3, 'first_name': 'Tina', 'last_name': 'Gilbert' },
+      { 'id': 4, 'first_name': 'Clarence', 'last_name': 'Flores' },
+      { 'id': 5, 'first_name': 'Anne', 'last_name': 'Lee' },
+      { 'id': 6, 'first_name': 'Rick', 'last_name': 'Potter' },
+      { 'id': 7, 'first_name': 'Harry', 'last_name': 'Sanchez' },
+      { 'id': 8, 'first_name': 'Joy', 'last_name': 'Mann' },
+      { 'id': 9, 'first_name': 'Adam', 'last_name': 'Hansen' },
+      { 'id': 10, 'first_name': 'Marge', 'last_name': 'Grey' }
+    ],
+    sortBy: 'id',
+    order: 'asc',
+    isClickable: true,
+    showNoDataText: false,
+    noDataText: 'No Data'
+  }
+},
+computed: {
+  filteredUsers () {
+    return this.showNoDataText ? [] : this.users
+  }
+},
+methods: {
+  sortTable (sortBy, order) {
+    this.users = orderBy(this.users, sortBy, order)
   }
 }`,
   apiRows: [
+    { name: 'condensed', type: 'Boolean', default: 'false', description: 'When set to true, this prop reduces appropriate styling to make table look condensed.' },
     { name: 'headers', type: 'Array', default: 'null', description: 'This prop contains an array of objects with header title, field and a sortable boolean to determine if your data should be sorted by that header.' },
     { name: 'isClickable', type: 'Boolean', default: 'false', description: 'When set to true, this prop adds appropriate styling to signify that the table and table rows are clickable.' },
-    { name: 'condensed', type: 'Boolean', default: 'false', description: 'When set to true, this prop reduces appropriate styling to make table look condensed.' },
+    { name: 'noDataText', type: 'String', default: '', description: 'Text to show when table has no data.' },
+    { name: 'order', type: 'String ("asc" or "desc")', default: 'desc', description: 'This prop defines which order (ascending or decending) is the default.' },
+    { name: 'showNoDataText', type: 'Boolean', default: 'false', description: 'When set to true, this prop displays the value of prop noDataText.' },
     { name: 'sortBy', type: 'String', default: 'null', description: 'This prop defines the default header to sort by.' },
-    { name: 'vAlign', type: 'String ("top" or "middle")', default: 'top', description: 'This prop defines which vertical alignment (top or middle) is the default.' },
-    { name: 'order', type: 'String ("asc" or "desc")', default: 'desc', description: 'This prop defines which order (ascending or decending) is the default.' }
+    { name: 'vAlign', type: 'String ("top" or "middle")', default: 'top', description: 'This prop defines which vertical alignment (top or middle) is the default.' }
   ]
 }

--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -10,18 +10,47 @@
         <ao-table
           :headers="headers"
           :is-clickable="isClickable"
+          :show-no-data-text="showNoDataText"
+          :no-data-text="noDataText"
           :sort-by="sortBy"
           :order="order"
           class="component-example-table"
           @sortTable="sortTable">
           <tr
-            v-for="user in users"
+            v-for="user in filteredUsers"
             :key="user.id">
             <td>{{ user.id }}</td>
             <td>{{ user.first_name }}</td>
             <td>{{ user.last_name }}</td>
           </tr>
         </ao-table>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="isClickable"
+            :checkbox-value="false"
+            checkbox-label="isClickable"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="showNoDataText"
+            :checkbox-value="false"
+            checkbox-label="showNoDataText"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="noDataText"
+            :type="'text'"
+            label="noDataText"
+          />
+        </div>
       </div>
     </div>
     <template slot="snippet">{{ snippet }}</template>
@@ -66,7 +95,14 @@ export default {
       ],
       sortBy: 'id',
       order: 'asc',
-      isClickable: false
+      isClickable: true,
+      showNoDataText: false,
+      noDataText: 'No Data'
+    }
+  },
+  computed: {
+    filteredUsers () {
+      return this.showNoDataText ? [] : this.users
     }
   },
   methods: {

--- a/docs/components/TextArea.vue
+++ b/docs/components/TextArea.vue
@@ -48,20 +48,20 @@
         <div class="component-controls__group">
           <ao-checkbox
             v-model="showLabel"
-            :checkbox-label="'showLabel'"
-            :checkbox-value="true" />
+            :checkbox-value="true"
+            checkbox-label="showLabel" />
         </div>
         <div class="component-controls__group">
           <ao-checkbox
             v-model="disabled"
-            :checkbox-label="'disabled'"
-            :checkbox-value="true" />
+            :checkbox-value="true"
+            checkbox-label="disabled" />
         </div>
         <div class="component-controls__group">
           <ao-checkbox
             v-model="invalid"
-            :checkbox-label="'invalid'"
-            :checkbox-value="true" />
+            :checkbox-value="true"
+            checkbox-label="invalid" />
         </div>
       </div>
     </div>

--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -14,6 +14,13 @@
     </thead>
     <tbody :class=" { clickable: isClickable }">
       <slot />
+      <tr
+        v-if="showNoDataText"
+        class="ao-table__nodata">
+        <td :colspan="headers.length">
+          {{ noDataText }}
+        </td>
+      </tr>
     </tbody>
     <tfoot v-if="hasTableFooterSlot">
       <slot name="table-footer"/>
@@ -39,6 +46,16 @@ export default {
     condensed: {
       type: Boolean,
       default: false
+    },
+
+    showNoDataText: {
+      type: Boolean,
+      default: false
+    },
+
+    noDataText: {
+      type: String,
+      default: ''
     },
 
     sortBy: {
@@ -124,6 +141,8 @@ export default {
 
 <style lang="scss">
 
+$table-row-background-shaded: $color-gray-90;
+
 .ao-table {
   border-collapse: collapse;
   border-spacing: 0;
@@ -154,18 +173,18 @@ export default {
     }
   }
 
-  &--clickable {
-    & > tbody > tr {
+  & > tbody > tr:nth-of-type(odd) {
+    background-color: $color-gray-90;
+  }
+
+  &.ao-table--clickable {
+    tbody > tr {
       cursor: pointer;
     }
 
     & > tbody > tr:hover {
       background: $color-gray-80;
     }
-  }
-
-  & > tbody > tr:nth-of-type(odd) {
-    background-color: $color-gray-90;
   }
 
   &--vertical-align-top {
@@ -223,6 +242,16 @@ export default {
 
   & tr:hover &__row-button {
     opacity: 1;
+  }
+
+  &__nodata {
+    text-align: center;
+    color: $color-gray-30;
+
+    &:hover {
+      cursor: inherit !important;
+      background-color: $table-row-background-shaded !important;
+    }
   }
 }
 </style>

--- a/tests/unit/AoTable.spec.js
+++ b/tests/unit/AoTable.spec.js
@@ -63,4 +63,27 @@ describe('Table', () => {
     triggerSort()
     expect(table.emitted().sortTable.length).toBe(3)
   })
+
+  it('nodata', () => {
+    const noDataSelector = '.ao-table__nodata'
+    const table = mount(Table, {
+      propsData: {
+        headers: [
+          { field: 'id', title: 'ID' },
+          { field: 'first_name', title: 'First Name' },
+          { field: 'last_name', title: 'Last Name' },
+          { field: 'gender', title: 'Gender' }
+        ]
+      }
+    })
+
+    expect(table.contains(noDataSelector)).toBe(false)
+
+    table.setProps({ showNoDataText: true })
+    expect(table.contains(noDataSelector)).toBe(true)
+    expect(table.find(noDataSelector).text()).toBe('')
+
+    table.setProps({ showNoDataText: true, noDataText: 'test' })
+    expect(table.find(noDataSelector).text()).toBe('test')
+  })
 })


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/57

# Description

support default empty state for AoTable and capability to override text

# Usage

`yarn serve`
Usage is specified in Table section and props documentation
Also try the demo for live action

# QA

`yarn test`
all tests should be passing