### PR TITLE
Table style fixes

### DIFF
--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -10,18 +10,37 @@
         <ao-table
           :headers="headers"
           :is-clickable="isClickable"
+          :show-no-data-text="showNoDataText"
           :sort-by="sortBy"
           :order="order"
           class="component-example-table"
           @sortTable="sortTable">
           <tr
-            v-for="user in users"
+            v-for="user in filteredUsers"
             :key="user.id">
             <td>{{ user.id }}</td>
             <td>{{ user.first_name }}</td>
             <td>{{ user.last_name }}</td>
           </tr>
         </ao-table>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="isClickable"
+            :checkbox-label="'isClickable'"
+            :checkbox-value="false"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="showNoDataText"
+            :checkbox-label="'showNoDataText'"
+            :checkbox-value="false"
+          />
+        </div>
       </div>
     </div>
     <template slot="snippet">{{ snippet }}</template>
@@ -66,7 +85,13 @@ export default {
       ],
       sortBy: 'id',
       order: 'asc',
-      isClickable: false
+      isClickable: true,
+      showNoDataText: false
+    }
+  },
+  computed: {
+    filteredUsers () {
+      return this.showNoDataText ? [] : this.users
     }
   },
   methods: {

--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -132,7 +132,7 @@ $table-row-background-shaded: $color-gray-90;
     background-color: $table-row-background-shaded;
   }
 
-  &--clickable {
+  &.ao-table--clickable {
     tbody > tr {
       cursor: pointer;
     }
@@ -194,17 +194,10 @@ $table-row-background-shaded: $color-gray-90;
   &__nodata {
     text-align: center;
     color: $color-gray-30;
-  }
 
-  &--clickable > tbody > &__nodata {
-    cursor: inherit;
-
-    &:nth-of-type(even) {
-      background-color: $color-white;
-    }
-
-    &:nth-of-type(odd) {
-      background-color: $table-row-background-shaded;
+    &:hover {
+      cursor: inherit !important;
+      background-color: $table-row-background-shaded !important;
     }
   }
 }


### PR DESCRIPTION
- added a `$table-row-background-shaded` variable to define the background color of the shaded rows, since it will now be referenced in another location
- moved position of style for shading the odd rows since it was incorrectly overriding the intended hover style
- Added styles to override hover styles for `nodata` row, if the table `isClickable`