### PR TITLE
Input, text box, select, file upload components invalid message, disabled functionality expanded

### DIFF
--- a/docs/components/FileUpload.js
+++ b/docs/components/FileUpload.js
@@ -11,7 +11,9 @@ export default {
     { name: 'name', type: 'String, required', default: '-', description: 'Specifies the name of the &lt;label&gt; element.' },
     { name: 'showLabel', type: 'Boolean', default: 'true', description: 'Hide or unhide the text label.' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' },
+    { name: 'disableAll', type: 'Boolean', default: 'false', description: 'Disables interaction with the component, greys out label.' },
     { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
-    { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' }
+    { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' },
+    { name: 'invalidMessage', type: 'String', default: 'null', description: 'Adds invalid messages below input' }
   ]
 }

--- a/docs/components/FileUpload.vue
+++ b/docs/components/FileUpload.vue
@@ -11,7 +11,9 @@
           :label="labelText"
           :show-label="showLabel"
           :disabled="disabled"
+          :disable-all="disableAll"
           :invalid="invalid"
+          :invalid-message="invalidMessage"
           name="'file'"
         />
       </div>
@@ -24,6 +26,13 @@
           />
         </div>
         <div class="component-controls__group">
+          <ao-input
+            v-model="invalidMessage"
+            :type="'text'"
+            :label="'Invalid Message'"
+          />
+        </div>
+        <div class="component-controls__group">
           <ao-checkbox
             v-model="showLabel"
             :checkbox-value="true"
@@ -33,6 +42,11 @@
             v-model="disabled"
             :checkbox-value="true"
             checkbox-label="disabled"
+          />
+          <ao-checkbox
+            v-model="disableAll"
+            :checkbox-value="true"
+            checkbox-label="disable all"
           />
           <ao-checkbox
             v-model="invalid"
@@ -67,7 +81,9 @@ export default {
       labelText: 'Upload File',
       showLabel: true,
       disabled: false,
-      invalid: false
+      disableAll: false,
+      invalid: false,
+      invalidMessage: 'INVALID!'
     }
   }
 }

--- a/docs/components/Input.js
+++ b/docs/components/Input.js
@@ -33,8 +33,11 @@ export default {
     { name: 'addOn', type: 'String', default: 'null', description: 'Appends text to the input.' },
     { name: 'step', type: 'Number', default: '1', description: 'Valid for input type "number". Defines the amount of changes per click.' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' },
+    { name: 'disableAll', type: 'Boolean', default: 'false', description: 'Disables interaction with the component, greys out label and instruction text.' },
     { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
     { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' },
-    { name: 'size', type: 'String (null or small)', default: 'null', description: 'Pass in \'small\' to decrease the size of the input field.' }
+    { name: 'invalidMessage', type: 'String', default: 'null', description: 'Adds invalid messages below input' },
+    { name: 'size', type: 'String (null or small)', default: 'null', description: 'Pass in \'small\' to decrease the size of the input field.' },
+    { name: 'min', type: '[String, Number]', default: 'null', description: 'Min date or min number' }
   ]
 }

--- a/docs/components/Input.vue
+++ b/docs/components/Input.vue
@@ -14,8 +14,11 @@
           :show-label="showLabel"
           :icon-html="iconHtml"
           :disabled="disabled"
+          :disable-all="disableAll"
           :invalid="invalid"
-        />
+          :invalid-message="invalidMessage"
+          :instruction-text="instructionText"
+          :min="minDate"/>
       </div>
       <div class="component-controls">
         <div class="component-controls__group">
@@ -44,6 +47,24 @@
           />
         </div>
       </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="invalidMessage"
+            :type="'text'"
+            :label="'Invalid Message'"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="instructionText"
+            :type="'text'"
+            :label="'Instruction Text'"
+          />
+        </div>
+      </div>
       <div class="component-controls__group">
         <ao-checkbox
           v-model="showLabel"
@@ -56,6 +77,13 @@
           v-model="disabled"
           :checkbox-value="false"
           checkbox-label="disabled"
+        />
+      </div>
+      <div class="component-controls__group">
+        <ao-checkbox
+          v-model="disableAll"
+          :checkbox-value="false"
+          checkbox-label="disable all"
         />
       </div>
       <div class="component-controls__group">
@@ -105,6 +133,7 @@
       <div class="component-example">
         <ao-input
           :label="dateLabel"
+          :min="minDate"
           type="date"
         />
       </div>
@@ -114,6 +143,15 @@
             v-model="dateLabel"
             :type="'text'"
             :label="'Input Label Text'"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="minDate"
+            :type="'date'"
+            :label="'Min Date'"
           />
         </div>
       </div>
@@ -146,10 +184,14 @@ export default {
       iconHtml: '&#10004;',
       addOn: 'years',
       disabled: false,
+      disableAll: false,
       invalid: false,
       numberLabel: 'Enter your age',
       step: 1,
-      dateLabel: 'Enter your date of birth'
+      dateLabel: 'Enter your date of birth',
+      invalidMessage: 'INVALID!',
+      instructionText: 'Must be 16 characters',
+      minDate: null
     }
   }
 }

--- a/docs/components/Select.js
+++ b/docs/components/Select.js
@@ -14,7 +14,7 @@ export default {
 </ao-select>
 
 data () {
-  return{
+  return {
     selected: null,
     options: [
       { value: 'Charmander', name: 'Charmander' },
@@ -30,7 +30,9 @@ data () {
     { name: 'showLabel', type: 'Boolean', default: 'true', description: 'This prop defines if the select label will be shown or not.' },
     { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
     { name: 'invalid', type: 'Boolean', default: 'false', description: 'This prop defines the select to be invalid.' },
+    { name: 'invalidMessage', type: 'String', default: 'false', description: 'Adds invalid messages below select' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'This prop disables the select.' },
+    { name: 'disableAll', type: 'Boolean', default: 'false', description: 'Disables interaction with the component, greys out label and instruction text.' },
     { name: 'placeholder', type: 'String', default: 'null', description: 'This prop defines the placeholder of the select.' },
     { name: 'size', type: 'String (null or small)', default: 'null', description: 'Pass in \'small\' to decrease the size of the input field.' }
   ]

--- a/docs/components/Select.vue
+++ b/docs/components/Select.vue
@@ -15,7 +15,9 @@
           :label="label"
           :placeholder="placeholder"
           :invalid="invalid"
+          :invalid-message="invalidMessage"
           :disabled="disabled"
+          :disable-all="disableAll"
           :show-label="showLabel">
           <option
             v-for="option in options"
@@ -41,6 +43,13 @@
           />
         </div>
         <div class="component-controls__group">
+          <ao-input
+            v-model="invalidMessage"
+            :type="'text'"
+            :label="'Invalid Message'"
+          />
+        </div>
+        <div class="component-controls__group">
           <ao-checkbox
             v-model="showLabel"
             :checkbox-value="true"
@@ -52,6 +61,13 @@
             v-model="disabled"
             :checkbox-value="true"
             checkbox-label="disabled"
+          />
+        </div>
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="disableAll"
+            :checkbox-value="true"
+            checkbox-label="disable all"
           />
         </div>
         <div class="component-controls__group">
@@ -91,6 +107,8 @@ export default {
       invalid: false,
       showLabel: true,
       disabled: false,
+      disableAll: false,
+      invalidMessage: 'INVALID!',
       options: [
         { value: 'Charmander', name: 'Charmander' },
         { value: 'Pikachu', name: 'Pikachu' },

--- a/docs/components/TextArea.js
+++ b/docs/components/TextArea.js
@@ -18,7 +18,9 @@ export default {
     { name: 'minLength', type: 'Number', default: '0', description: 'Defines the minimum length of characters within the text area.' },
     { name: 'rows', type: 'Number', default: '5', description: 'Defines the number of rows of the text area.' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' },
+    { name: 'disableAll', type: 'Boolean', default: 'false', description: 'Disables interaction with the component, greys out label and instruction text.' },
     { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
-    { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' }
+    { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' },
+    { name: 'invalidMessage', type: 'String', default: 'false', description: 'Adds invalid messages below input' }
   ]
 }

--- a/docs/components/TextArea.vue
+++ b/docs/components/TextArea.vue
@@ -14,7 +14,9 @@
           :rows="rowLength"
           :max-length="maxCharacters"
           :disabled="disabled"
-          :invalid="invalid" />
+          :disable-all="disableAll"
+          :invalid-message="invalidMessage"
+          :invalid="invalid"/>
       </div>
       <div class="component-controls">
         <div class="component-controls__group">
@@ -46,6 +48,13 @@
           />
         </div>
         <div class="component-controls__group">
+          <ao-input
+            v-model="invalidMessage"
+            :type="'text'"
+            :label="'Invalid Message'"
+          />
+        </div>
+        <div class="component-controls__group">
           <ao-checkbox
             v-model="showLabel"
             :checkbox-value="true"
@@ -56,6 +65,12 @@
             v-model="disabled"
             :checkbox-value="true"
             checkbox-label="disabled" />
+        </div>
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="disableAll"
+            :checkbox-value="true"
+            checkbox-label="disable all" />
         </div>
         <div class="component-controls__group">
           <ao-checkbox
@@ -92,9 +107,11 @@ export default {
       rowLength: 5,
       maxCharacters: 100000,
       disabled: false,
+      disableAll: false,
       invalid: false,
       showLabel: true,
-      textAreaText: 'Tell us your favourite funny quote'
+      textAreaText: 'Tell us your favourite funny quote',
+      invalidMessage: 'INVALID!'
     }
   }
 }

--- a/src/assets/styles/mixins/shared-input-styles.scss
+++ b/src/assets/styles/mixins/shared-input-styles.scss
@@ -46,10 +46,15 @@
       font-size: $font-size-sm;
     }
   }
-  .ao-input-group {
-    display: table;
-    border-collapse: separate;
-    & .ao-form-control {
+  
+  .ao-input{
+  
+    &--has-addon {
+      display: table;
+      border-collapse: separate;
+    }
+    
+    &--has-addon > .ao-form-control {
       display: table-cell;
       width: 100%;
       margin-bottom: 0;
@@ -58,7 +63,8 @@
         border-top-right-radius: 0;
       }
     }
-    &__addon {
+    
+    &--has-addon > &__addon {
       align-items: center;
       height: $input-height-base;
       padding: $spacer-micro $spacer-sm;
@@ -80,26 +86,49 @@
       }
     }
   }
+
   .ao-form-group {
     margin-bottom: $spacer;
+    
     label {
       display: inline-block;
       max-width: 100%;
       margin: $input-label-margin;
       font-weight: $font-weight-bold;
     }
-  }
-
-  .ao-form-group__label {
-    & .ao-tooltip {
-      margin-left: $spacer-micro;
+    
+    &__label {
+      & .ao-tooltip {
+        margin-left: $spacer-micro;
+      }
     }
-  }
   
-  .ao-form-group__instruction-text {
-    display: block;
-    font-size: $font-size-xs;
-    color: $color-gray-30;
-    margin-top: $spacer-micro;
+    &--has-feedback {
+      .ao-input {
+        margin-bottom: $spacer-micro;
+      }
+    }
+    
+    &__instruction-text {
+      display: block;
+      font-size: $font-size-xs;
+      color: $color-gray-30;
+      margin-top: $spacer-micro
+    }
+  
+    &__invalid-message {
+      display: block;
+      font-size: $font-size-xs;
+      color: $font-color-error;
+      margin-top: $spacer-micro
+    }
+  
+    &__instruction-text {
+      margin-top: 0;
+    }
+  
+    &--disabled {
+      opacity: 0.6;
+    }
   }
 }

--- a/src/components/AoFileUpload.vue
+++ b/src/components/AoFileUpload.vue
@@ -1,19 +1,23 @@
 <template>
-  <div class="ao-form-group">
+  <div :class="['ao-form-group', {'ao-form-group--disabled': disableAll}, {'ao-form-group--has-feedback': hasFeedbackText }]">
     <div
       v-show="showLabel"
       class="ao-form-group__label">
-      <label
-        :for="name">{{ label }}</label>
+      <label :for="name">{{ label }}</label>
       <slot name="fileUploadLabelTooltip"/>
     </div>
     <input
       :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
       :name="name"
-      :disabled="disabled"
+      :disabled="disabled || disableAll"
       type="file"
       @change="updateFile($event.target.files)"
       @blur="emitBlur($event)">
+    <span
+      v-show="invalidMessage && invalid"
+      class="ao-form-group__invalid-message">
+      {{ invalidMessage }}
+    </span>
     <span
       v-if="instructionText"
       class="ao-form-group__instruction-text">
@@ -40,9 +44,19 @@ export default {
       default: false
     },
 
+    disableAll: {
+      type: Boolean,
+      default: false
+    },
+
     invalid: {
       type: Boolean,
       default: false
+    },
+
+    invalidMessage: {
+      type: String,
+      default: null
     },
 
     name: {
@@ -53,6 +67,12 @@ export default {
     instructionText: {
       type: String,
       default: null
+    }
+  },
+
+  computed: {
+    hasFeedbackText () {
+      return this.instructionText || (this.invalidMessage && this.invalid)
     }
   },
 

--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -1,34 +1,41 @@
 <template>
-  <div class="ao-form-group">
+  <div :class="['ao-form-group', {'ao-form-group--disabled': disableAll}, {'ao-form-group--has-feedback': hasFeedbackText }]">
     <div
       v-show="showLabel"
       class="ao-form-group__label">
-      <label
-        :for="name">{{ label }}</label>
+      <label :for="name">
+        {{ label }}
+      </label>
       <slot name="tooltip"/>
     </div>
-    <div :class="{ 'ao-input-group': hasInputGroup }">
+    <div :class="['ao-input', { 'ao-input--has-addon': hasInputGroup }]">
       <input
         :class="['ao-form-control', {'ao-form-control--invalid': invalid }, computedSize]"
         :type="type"
         :placeholder="placeholder"
         :name="name"
         :value="value"
-        :disabled="disabled"
+        :disabled="disabled || disableAll"
         :step="step"
+        :min="min"
         @input="updateValue($event.target.value)"
         @blur="emitBlur($event)">
       <span
         v-if="hasIconAddon"
         :class="iconClass"
-        class="ao-input-group__addon"
+        class="ao-input__addon"
         v-html="iconHtml"/>
       <span
         v-if="hasAddOn"
-        class="ao-input-group__addon">
+        class="ao-input__addon">
         {{ addOn }}
       </span>
     </div>
+    <span
+      v-show="invalidMessage && invalid"
+      class="ao-form-group__invalid-message">
+      {{ invalidMessage }}
+    </span>
     <span
       v-if="instructionText"
       class="ao-form-group__instruction-text">
@@ -96,6 +103,11 @@ export default {
       default: false
     },
 
+    disableAll: {
+      type: Boolean,
+      default: false
+    },
+
     step: {
       type: Number,
       default: 1
@@ -104,6 +116,11 @@ export default {
     invalid: {
       type: Boolean,
       default: false
+    },
+
+    invalidMessage: {
+      type: String,
+      default: null
     },
 
     size: {
@@ -116,6 +133,11 @@ export default {
 
     instructionText: {
       type: String,
+      default: null
+    },
+
+    min: {
+      type: [String, Number],
       default: null
     }
   },
@@ -131,6 +153,10 @@ export default {
 
     hasAddOn () {
       return this.addOn
+    },
+
+    hasFeedbackText () {
+      return this.instructionText || (this.invalidMessage && this.invalid)
     },
 
     computedSize () {
@@ -157,5 +183,4 @@ export default {
 
 @import '../assets/styles/mixins/shared-input-styles.scss';
 @include shared-input-styles;
-
 </style>

--- a/src/components/AoSelect.vue
+++ b/src/components/AoSelect.vue
@@ -1,17 +1,16 @@
 <template>
-  <div class="ao-form-group">
+  <div :class="['ao-form-group', {'ao-form-group--disabled': disableAll}, {'ao-form-group--has-feedback': hasFeedbackText }]">
     <div
       v-show="showLabel"
       class="ao-form-group__label">
-      <label
-        :for="name">{{ label }}</label>
+      <label :for="name">{{ label }}</label>
       <slot name="tooltip"/>
     </div>
-    <div :class="{ 'ao-input-group': hasInputGroup }">
+    <div class="ao-input">
       <select
         :value="selected"
         :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control', computedSize]"
-        :disabled="disabled"
+        :disabled="disabled || disableAll"
         @change="updateInput"
         @blur="emitBlur($event)">
         <option
@@ -22,6 +21,11 @@
         <slot/>
       </select>
     </div>
+    <span
+      v-show="invalidMessage && invalid"
+      class="ao-form-group__invalid-message">
+      {{ invalidMessage }}
+    </span>
     <span
       v-if="instructionText"
       class="ao-form-group__instruction-text">
@@ -55,6 +59,11 @@ export default {
       default: false
     },
 
+    invalidMessage: {
+      type: String,
+      default: null
+    },
+
     disabled: {
       type: Boolean,
       default: false
@@ -76,6 +85,11 @@ export default {
     instructionText: {
       type: String,
       default: null
+    },
+
+    disableAll: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -91,6 +105,10 @@ export default {
         'ao-form-control--small': this.size === 'small'
       }
       return filterClasses(activeClasses)
+    },
+
+    hasFeedbackText () {
+      return this.instructionText || (this.invalidMessage && this.invalid)
     }
   },
 

--- a/src/components/AoTextArea.vue
+++ b/src/components/AoTextArea.vue
@@ -1,11 +1,10 @@
 <template>
   <!-- investigate min max length -->
-  <div class="ao-form-group">
+  <div :class="['ao-form-group', {'ao-form-group--disabled': disableAll}, {'ao-form-group--has-feedback': hasFeedbackText }]">
     <div
       v-show="showLabel"
       class="ao-form-group__label">
-      <label
-        :for="name">{{ label }}</label>
+      <label :for="name">{{ label }}</label>
       <slot name="tooltip"/>
     </div>
     <textarea
@@ -16,11 +15,16 @@
       :rows="rows"
       :maxlength="maxLength"
       :minlength="minLength"
-      :disabled="disabled"
+      :disabled="disabled || disableAll"
       class="ao-form-control"
       @input="inputEvent($event.target.value)"
       @blur="emitBlur($event)"
     />
+    <span
+      v-show="invalidMessage && invalid"
+      class="ao-form-group__invalid-message">
+      {{ invalidMessage }}
+    </span>
     <span
       v-if="instructionText"
       class="ao-form-group__instruction-text">
@@ -67,6 +71,11 @@ export default {
       default: false
     },
 
+    disableAll: {
+      type: Boolean,
+      default: false
+    },
+
     rows: {
       type: Number,
       default: 5
@@ -77,6 +86,11 @@ export default {
       default: false
     },
 
+    invalidMessage: {
+      type: String,
+      default: null
+    },
+
     showLabel: {
       type: Boolean,
       default: true
@@ -85,6 +99,12 @@ export default {
     instructionText: {
       type: String,
       default: null
+    }
+  },
+
+  computed: {
+    hasFeedbackText () {
+      return this.instructionText || (this.invalidMessage && this.invalid)
     }
   },
 

--- a/tests/unit/AoFileUpload.spec.js
+++ b/tests/unit/AoFileUpload.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import FileUpload from '@/components/AoFileUpload.vue'
 import instructionText from './helpers/instructionText'
+import invalidMessage from './helpers/invalidMessage'
 
 describe('FileUpload', () => {
   it('create', () => {
@@ -71,5 +72,16 @@ describe('FileUpload', () => {
     })
 
     instructionText.assert(fileUpload)
+  })
+
+  it('invalid message', () => {
+    const fileUpload = mount(FileUpload, {
+      propsData: {
+        name: 'text',
+        label: 'test'
+      }
+    })
+
+    invalidMessage.assert(fileUpload)
   })
 })

--- a/tests/unit/AoInput.spec.js
+++ b/tests/unit/AoInput.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import Input from '@/components/AoInput.vue'
 import instructionText from './helpers/instructionText'
+import invalidMessage from './helpers/invalidMessage'
 
 describe('Input', () => {
   const getFormControlElement = (wrapper) => wrapper.find('.ao-form-control')
@@ -83,5 +84,16 @@ describe('Input', () => {
     })
 
     instructionText.assert(input)
+  })
+
+  it('invalid message', () => {
+    const input = mount(Input, {
+      propsData: {
+        type: 'text',
+        label: 'test'
+      }
+    })
+
+    invalidMessage.assert(input)
   })
 })

--- a/tests/unit/AoSelect.spec.js
+++ b/tests/unit/AoSelect.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import Select from '@/components/AoSelect.vue'
 import instructionText from './helpers/instructionText'
+import invalidMessage from './helpers/invalidMessage'
 
 describe('Select', () => {
   it('create', () => {
@@ -80,5 +81,15 @@ describe('Select', () => {
 
     select.find('.ao-form-control').trigger('blur')
     expect(select.emitted().blur).toBeTruthy()
+  })
+
+  it('invalid message', () => {
+    const select = mount(Select, {
+      propsData: {
+        label: 'test'
+      }
+    })
+
+    invalidMessage.assert(select)
   })
 })

--- a/tests/unit/AoTextArea.spec.js
+++ b/tests/unit/AoTextArea.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils'
 import TextArea from '@/components/AoTextArea.vue'
 import instructionText from './helpers/instructionText'
+import invalidMessage from './helpers/invalidMessage'
 
 describe('TextArea', () => {
   it('create', () => {
@@ -43,5 +44,11 @@ describe('TextArea', () => {
     const textArea = mount(TextArea)
 
     instructionText.assert(textArea)
+  })
+
+  it('invalid message', () => {
+    const textArea = mount(TextArea)
+
+    invalidMessage.assert(textArea)
   })
 })

--- a/tests/unit/helpers/invalidMessage.js
+++ b/tests/unit/helpers/invalidMessage.js
@@ -1,0 +1,13 @@
+const invalidMessageSelector = '.ao-form-group__invalid-message'
+
+export default {
+  assert (wrapper) {
+    expect(wrapper.contains(invalidMessageSelector)).toBe(true)
+    expect(wrapper.find(invalidMessageSelector).text()).toBe('')
+
+    wrapper.setProps({
+      invalidMessage: 'invalid message'
+    })
+    expect(wrapper.find(invalidMessageSelector).text()).toBe('invalid message')
+  }
+}


### PR DESCRIPTION
# Link to Github Issue
[Issue-45](https://github.com/AmpleOrganics/Blaze.vue/issues/45)

# Description
- Add error message to input, text box, select, file upload components
- Disabled functionality expanded to include label
- Added min prop to input