### PR TITLE
199 - header toolbar title and logo are clickable

### DIFF
--- a/docs/components/HeaderToolbar.js
+++ b/docs/components/HeaderToolbar.js
@@ -11,6 +11,7 @@ export default {
 </ao-header-toolbar>`,
   apiRows: [
     { name: 'title', type: 'String, required', default: 'null', description: 'Defines the header toolbar title.' },
+    { name: 'titleClicked', type: 'Function', default: 'null', description: 'Callback function to invoke when header toolbar title is clicked.' },
     { name: 'iconHtml', type: 'String', default: 'null', description: 'Accepts html elements or html codes for icons.' },
     { name: 'iconUrl', type: 'String', default: 'null', description: 'Accepts an image URL.' },
     { name: 'iconClass', type: 'String', default: 'null', description: 'Accepts icon class components e.g. glyphicons.' },

--- a/docs/components/HeaderToolbar.vue
+++ b/docs/components/HeaderToolbar.vue
@@ -10,22 +10,42 @@
         <ao-header-toolbar
           :title="titleText"
           :icon-html="iconHtml"
-          :icon-url="iconUrl">
+          :icon-url="iconUrl"
+          :title-clicked="titleClicked">
           <span class="icon">🍔</span>
           <span>Logout</span>
         </ao-header-toolbar>
       </div>
       <div class="component-controls">
-        <ao-input
-          v-model="titleText"
-          :label="'Header Toolbar Title Text'"/>
-        <ao-input
-          v-model="iconHtml"
-          :label="'iconHtml'"/>
-        <ao-input
-          v-model="iconUrl"
-          :label="'iconUrl'"
-          :placeholder="'https://vignette.wikia.nocookie.net/2007scape/images/7/7f/Chompy_bird.png/revision/latest?cb=20160714233624'"/>
+        <div class="component-controls__group">
+          <ao-input
+            v-model="titleText"
+            :label="'Header Toolbar Title Text'"/>
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="iconHtml"
+            :label="'iconHtml'"/>
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="iconUrl"
+            :label="'iconUrl'"
+            :placeholder="'https://vignette.wikia.nocookie.net/2007scape/images/7/7f/Chompy_bird.png/revision/latest?cb=20160714233624'"/>
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="isTitleClickable"
+            :checkbox-value="false"
+            checkbox-label="isTitleClickable"
+          />
+        </div>
       </div>
     </div>
     <template slot="snippet">{{ snippet }}</template>
@@ -52,7 +72,20 @@ export default {
       ...HeaderToolbarDocumentation,
       titleText: 'Ribbitting Technologies',
       iconHtml: '🐸',
-      iconUrl: null
+      iconUrl: null,
+      isTitleClickable: false
+    }
+  },
+  computed: {
+    titleClicked () {
+      return this.isTitleClickable ? this.onTitleClick : null
+    }
+  },
+  methods: {
+    onTitleClick () {
+      if (console && console.log) {
+        console.log('Header Toolbar title was clicked')
+      }
     }
   }
 }

--- a/docs/helpers/EventTable.vue
+++ b/docs/helpers/EventTable.vue
@@ -1,0 +1,33 @@
+<template>
+  <ao-table
+    v-if="rows.length"
+    :headers="headers">
+    <tr
+      v-for="(row, index) in rows"
+      :key="index">
+      <td>{{ row.name }}</td>
+      <td>{{ row.description }}</td>
+    </tr>
+  </ao-table>
+  <div v-else>
+    There are no props for this component.
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    headers: {
+      type: Array,
+      default: () => ([
+        { field: 'name', title: 'Name', sortable: false },
+        { field: 'description', title: 'Description', sortable: false }
+      ])
+    },
+    rows: {
+      type: Array,
+      default: () => ([])
+    }
+  }
+}
+</script>

--- a/docs/layout/Layout.vue
+++ b/docs/layout/Layout.vue
@@ -3,8 +3,8 @@
     <div class="layout__header-toolbar">
       <ao-header-toolbar
         :title="title"
-        fixed
-        @click.native="$router.push('/')"/>
+        :title-clicked="titleClicked"
+        fixed/>
     </div>
 
     <div class="layout__container">
@@ -38,6 +38,13 @@
               <h2>Props</h2>
               <slot name="api">api</slot>
             </div>
+
+            <div
+              v-if="isEventsSectionVisible"
+              class="layout__section">
+              <h2>Events</h2>
+              <slot name="events"/>
+            </div>
           </slot>
         </ao-card>
       </div>
@@ -55,9 +62,14 @@ export default {
   data: () => ({
     title: 'Blaze Documentation'
   }),
+  computed: {
+    isEventsSectionVisible () {
+      return Object.keys(this.$slots).includes('events')
+    }
+  },
   methods: {
-    onClick () {
-      console.log('clicked')
+    titleClicked () {
+      this.$router.push('/')
     }
   }
 }
@@ -99,10 +111,6 @@ export default {
   &__description {
     color: $color-gray-30;
     font-size: $font-size-lg;
-  }
-
-  &__header-toolbar {
-    cursor: pointer;
   }
 
   .component-example {

--- a/docs/layout/LayoutSidebar.vue
+++ b/docs/layout/LayoutSidebar.vue
@@ -1,9 +1,6 @@
 <template>
   <ao-card class="layoutsidebar">
     <nav>
-      <ao-heading
-        card-section-heading
-        text="Components"/>
       <ul>
         <li
           v-for="route in componentRoutes"

--- a/src/components/AoHeaderToolbar.vue
+++ b/src/components/AoHeaderToolbar.vue
@@ -2,17 +2,26 @@
   <header
     :class="{ 'ao-header-toolbar--fixed': fixed }"
     class="ao-header-toolbar">
-    <div class="ao-header-toolbar__title">
+    <div
+      :class="{ 'clickable': isClickable }"
+      class="ao-header-toolbar__title">
       <span
         v-if="hasIconAddon"
         :class="iconClass"
         class="ao-header-toolbar__icon"
+        @click="onTitleClick"
         v-html="iconHtml"/>
       <img
         v-if="hasIconUrlAddon"
         :src="iconUrl"
-        class="ao-header-toolbar__icon">
-      <span class="ao-header-toolbar__title-text">{{ title }}</span>
+        class="ao-header-toolbar__icon"
+        @click="onTitleClick">
+      <span
+        :class="iconClass"
+        class="ao-header-toolbar__title-text"
+        @click="onTitleClick">
+        {{ title }}
+      </span>
     </div>
     <div class="ao-header-toolbar__controls">
       <slot />
@@ -26,6 +35,10 @@ export default {
     title: {
       type: String,
       required: true
+    },
+    titleClicked: {
+      type: Function,
+      default: null
     },
     iconUrl: {
       type: String,
@@ -51,6 +64,15 @@ export default {
     },
     hasIconUrlAddon () {
       return this.iconUrl
+    },
+    isClickable () {
+      return !!this.titleClicked
+    }
+  },
+
+  methods: {
+    onTitleClick () {
+      this.titleClicked && this.titleClicked()
     }
   }
 }
@@ -116,6 +138,10 @@ export default {
         cursor: pointer;
       }
     }
+  }
+
+  &__title.clickable > * {
+    cursor: pointer;
   }
 
   &--fixed {

--- a/tests/unit/AoHeaderToolbar.spec.js
+++ b/tests/unit/AoHeaderToolbar.spec.js
@@ -33,4 +33,26 @@ describe('HeaderToolbar', () => {
     })
     expect(headerToolbar.find('.ao-header-toolbar--fixed').exists()).toBe(true)
   })
+
+  it('raise onTitleClick event', () => {
+    const titleClicked = jest.fn()
+    const headerToolbar = mount(HeaderToolbar, {
+      propsData: {
+        title: 'Test',
+        titleClicked,
+        iconHtml: '<i>icon</i>',
+        iconUrl: ''
+      }
+    })
+
+    headerToolbar.find('.ao-header-toolbar__icon').trigger('click')
+    expect(titleClicked.mock.calls.length).toBe(1)
+
+    headerToolbar.find('.ao-header-toolbar__title-text').trigger('click')
+    expect(titleClicked.mock.calls.length).toBe(2)
+
+    headerToolbar.setProps({ iconHtml: '', iconUrl: '#' })
+    headerToolbar.find('.ao-header-toolbar__icon').trigger('click')
+    expect(titleClicked.mock.calls.length).toBe(3)
+  })
 })


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/199

# Description

Header Toolbar's title and logo should be clickable

# QA
`yarn serve`

Navigate to `Header Toolbar`
Check on `isTitleClickable` check box
Open browser console
Click on heading tool title or logo
console shows message `Header Toolbar title was clicked`