### PR TITLE
Callout:  Added dismissible and icon props - issues 242/243

### DIFF
--- a/docs/components/Callout.js
+++ b/docs/components/Callout.js
@@ -1,0 +1,22 @@
+export default {
+  header: 'Callout',
+  description: 'This is a customizable callout component.',
+  snippet:
+        `<ao-callout
+      v-if="showCallout"
+      success
+      dismissible
+      :icon-class="'glyphicon glyphicon-ok'"
+      @hideCallout="hideCallout">
+      Callout text goes here
+    </ao-callout>`,
+  apiRows: [
+    { name: 'iconClass', type: 'String', default: 'null', description: 'Displays icon components eg. glyphicons.' },
+    { name: 'dismissible', type: 'Boolean', default: 'false', description: 'Displays a close icon on right side of callout' },
+    { name: 'destructive', type: 'Boolean', default: 'false', description: 'Adds a class to indicate a destructive action eg. deletion, permanent irreversible action.' },
+    { name: 'caution', type: 'Boolean', default: 'false', description: 'Adds a class to indicate a cautious action eg. reversible powerful change.' },
+    { name: 'success', type: 'Boolean', default: 'false', description: 'Adds a class to indicate a success action.' },
+    { name: 'info', type: 'Boolean', default: 'false', description: 'Adds a class to indicate an informative action.' },
+    { name: '@hideCallout', type: 'Event', default: 'null', description: 'Event emitted to allow the callout to be shown or hidden' }
+  ]
+}

--- a/docs/components/Callout.vue
+++ b/docs/components/Callout.vue
@@ -1,0 +1,131 @@
+<template>
+  <layout>
+    <template slot="description">
+      <span v-html="description" />
+    </template>
+
+    <div slot="example">
+      <div class="component-example">
+        <ao-callout
+          v-if="showCallout"
+          :dismissible="selectedDismissible"
+          :icon-class="iconClass"
+          :success="selectedStyle === 'success'"
+          :caution="selectedStyle === 'caution'"
+          :destructive="selectedStyle === 'destructive'"
+          :info="selectedStyle === 'info'"
+          @hideCallout="hideCallout"
+        >
+          <p>{{ calloutText }}</p>
+        </ao-callout>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="calloutText"
+            :type="'text'"
+            :label="'Callout Text'"
+          />
+        </div>
+        <div class="component-controls__group">
+          <ao-input
+            v-model="iconClass"
+            :type="'text'"
+            :label="'Callout Icon'"
+          />
+        </div>
+        <br>
+        <div class="component-controls__group">
+          <label>Callout Style</label>
+          <ao-radio
+            v-for="style in calloutStyles"
+            :key="style.value"
+            v-model="selectedStyle"
+            :val="style.value"
+            :name="style.name"
+            :label="style.name"
+          />
+        </div>
+        <br>
+        <div class="component-controls__group">
+          <label>Callout Is Dismissible</label>
+          <ao-radio
+            v-for="radio in dismissibleRadios"
+            :key="radio.value"
+            v-model="selectedDismissible"
+            :val="radio.value"
+            :name="radio.name"
+            :label="radio.name"
+          />
+        </div>
+        <br>
+        <div class="component-controls__group">
+          <label>Show Or Hide Callout</label>
+          <ao-radio
+            v-for="radio in showCalloutRadios"
+            :key="radio.value"
+            v-model="showCallout"
+            :val="radio.value"
+            :name="radio.name"
+            :label="radio.name"
+            :disabled="!selectedDismissible"
+          />
+        </div>
+      </div>
+    </div>
+    <template slot="snippet">
+      {{ snippet }}
+    </template>
+    <template slot="api">
+      <ApiTable :rows="apiRows" />
+    </template>
+  </layout>
+</template>
+
+<script>
+import Layout from '../layout/Layout'
+import ApiTable from '../helpers/ApiTable'
+import CalloutDocumentation from './Callout'
+
+export default {
+  components: {
+    Layout,
+    ApiTable
+  },
+
+  data () {
+    return {
+      ...CalloutDocumentation,
+      showCallout: true,
+      iconClass: 'glyphicon glyphicon-ok',
+      calloutStyles: [
+        { name: 'success', value: 'success' },
+        { name: 'destructive', value: 'destructive' },
+        { name: 'caution', value: 'caution' },
+        { name: 'info', value: 'info' }
+      ],
+      selectedStyle: 'success',
+      dismissibleRadios: [
+        { name: 'dismissible', value: true },
+        { name: 'not dismissible', value: false }
+      ],
+      showCalloutRadios: [
+        { name: 'show callout', value: true },
+        { name: 'hide callout', value: false }
+      ],
+      selectedDismissible: false,
+      calloutText: 'This is a callout'
+    }
+  },
+
+  methods: {
+    hideCallout () {
+      this.showCallout = false
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/docs/components/Radio.js
+++ b/docs/components/Radio.js
@@ -24,7 +24,7 @@ data() {
   }
 }`,
   apiRows: [
-    { name: 'val', type: '[String, Number], required', default: 'null', description: 'This prop defines the actual value of a radio button.' },
+    { name: 'val', type: '[String, Number, Boolean], required', default: 'null', description: 'This prop defines the actual value of a radio button.' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'This prop defines if the modal will ve disabled.' },
     { name: 'label', type: 'Boolean', default: 'false', description: 'This prop defines the label of the radio button.' }
   ]

--- a/docs/components/RadioButtonGroup.js
+++ b/docs/components/RadioButtonGroup.js
@@ -5,7 +5,7 @@ export default {
         `<ao-radio-button-group
     :options="radioOptions"
     :name="'radio'"
-    v-model="radioGroupVal"
+    v-model="selectedRadio"
   />
 
   data () {

--- a/src/components/AoCallout.vue
+++ b/src/components/AoCallout.vue
@@ -1,6 +1,22 @@
 <template>
   <div :class="[computedClasses, 'ao-callout']">
-    <slot />
+    <div>
+      <i
+        v-if="iconClass"
+        :class="[iconClass, 'ao-callout__icon']"
+      />
+    </div>
+    <div class="ao-callout__body">
+      <slot />
+    </div>
+    <div class="ao-callout__dismiss-icon">
+      <button
+        v-if="dismissible"
+        @click="dismissCallout"
+      >
+        <i class="glyphicon glyphicon-remove" />
+      </button>
+    </div>
   </div>
 </template>
 
@@ -23,6 +39,14 @@ export default {
     destructive: {
       type: Boolean,
       default: false
+    },
+    iconClass: {
+      type: String,
+      default: null
+    },
+    dismissible: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -36,38 +60,83 @@ export default {
       }
       return filterClasses(computedClasses)
     }
+  },
+
+  methods: {
+    dismissCallout () {
+      this.$emit('hideCallout')
+    }
   }
 }
 </script>
 
-<style lang='scss' scoped>
+<style lang='scss'>
+  @mixin callout-style($background, $color){
+    background: $background;
+    color: $color;
+
+    .ao-callout__dismiss-icon button {
+      color: $color;
+    }
+  }
+
   .ao-callout {
+    display: flex;
     padding: $spacer;
     margin-bottom: $spacer;
     background: $color-gray-90;
 
-    *:last-child {
+    &__body > *:last-child {
       margin-bottom: 0;
     }
 
     &--info {
-      background: $color-info-light;
-      color: $color-info-dark;
+      @include callout-style($color-info-light, $color-info-dark)
     }
 
     &--success {
-      background: $color-success-light;
-      color: $color-success-dark;
+      @include callout-style($color-success-light, $color-success-dark)
     }
 
     &--caution {
-      background: $color-caution-light;
-      color: $color-caution-dark;
+      @include callout-style($color-caution-light, $color-caution-dark)
     }
 
     &--destructive {
-      background: $color-destructive-light;
-      color: $color-destructive-dark;
+      @include callout-style($color-destructive-light, $color-destructive-dark)
+    }
+
+    &__icon {
+      margin-right: $spacer;
+      font-size: $font-size-xl;
+      opacity: 0.2;
+    }
+
+    &__body {
+      display: inline-flex;
+      flex-direction: column;
+      justify-content: center;
+      flex-grow: 1;
+    }
+
+    &__dismiss-icon {
+      display: flex;
+      flex-direction: column;
+
+      button {
+        background: transparent;
+        border: 0;
+        height: auto;
+        width: auto;
+        flex-grow: 0;
+        opacity: .6;
+        font-size: $font-size-sm;
+        padding: 0;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
     }
   }
 

--- a/src/components/AoRadio.vue
+++ b/src/components/AoRadio.vue
@@ -17,12 +17,12 @@ export default {
   props: {
     // consistant naming and proxy for vue magic
     value: {
-      type: [String, Number],
+      type: [String, Number, Boolean],
       required: true
     },
 
     val: {
-      type: [String, Number],
+      type: [String, Number, Boolean],
       required: true
     },
 

--- a/src/router.js
+++ b/src/router.js
@@ -8,6 +8,7 @@ import Breadcrumbs from '../docs/components/Breadcrumbs.vue'
 import Button from '../docs/components/Button.vue'
 import Card from '../docs/components/Card.vue'
 import Checkbox from '../docs/components/Checkbox.vue'
+import Callout from '../docs/components/Callout.vue'
 import Dropdown from '../docs/components/Dropdown.vue'
 import FileUpload from '../docs/components/FileUpload.vue'
 import HeaderToolbar from '../docs/components/HeaderToolbar.vue'
@@ -44,6 +45,7 @@ export default new Router({
     { name: 'badge', path: '/badge', component: Badge, meta: { title: 'Badge' } },
     { name: 'breadcrumbs', path: '/breadcrumbs', component: Breadcrumbs, meta: { title: 'Breadcrumbs' } },
     { name: 'button', path: '/button', component: Button, meta: { title: 'Button' } },
+    { name: 'callout', path: '/callout', component: Callout, meta: { title: 'Callout' } },
     { name: 'card', path: '/card', component: Card, meta: { title: 'Card' } },
     { name: 'checkbox', path: '/checkbox', component: Checkbox, meta: { title: 'Checkbox' } },
     { name: 'dropdown', path: '/dropdown', component: Dropdown, meta: { title: 'Dropdown' } },

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -513,8 +513,13 @@
         >
           I am a card callout! I am passed into the cardCallout slot and am flush with the card.
         </ao-callout>
-        <ao-callout>
-          <p>This is default callout</p>
+        <ao-callout
+          :icon-class="'glyphicon glyphicon-ok'"
+          :show-callout.sync="showCallout"
+          dismissible
+          success
+        >
+          This is default callout
         </ao-callout>
         <ao-callout info>
           <p>This is an info callout</p>
@@ -643,6 +648,7 @@ export default {
   name: 'DemoContainer',
   data () {
     return {
+      showCallout: true,
       saveData: {},
       name: null,
       age: 100,

--- a/tests/unit/AoCallout.spec.js
+++ b/tests/unit/AoCallout.spec.js
@@ -42,4 +42,33 @@ describe('Callout', () => {
     })
     expect(callout.classes()).toContain('ao-callout--destructive')
   })
+
+  it('is dismissible', () => {
+    const callout = mount(Callout, {
+      propsData: {
+        dismissible: true,
+        showCallout: true
+      }
+    })
+    expect(callout.contains('ao-callout__dismiss-icon'))
+  })
+
+  it('has an icon', () => {
+    const callout = mount(Callout, {
+      propsData: {
+        iconClass: 'glyphicon'
+      }
+    })
+    expect(callout.contains('glyphicon'))
+  })
+
+  it('emits an update', () => {
+    const callout = mount(Callout, {
+      propsData: {
+        dismissible: true
+      }
+    })
+    callout.find('.ao-callout__dismiss-icon button').trigger('click')
+    expect(callout.emitted()['hideCallout'][0][0]).toBeFalsy()
+  })
 })


### PR DESCRIPTION
# Link to Github Issue

[242](https://github.com/AmpleOrganics/Blaze.vue/issues/242)
[243](https://github.com/AmpleOrganics/Blaze.vue/issues/243)

# Description

- Added dismissible function so that the callout can be dismissed. 
- Updated documentation
- Fixed issue in radio button group documentation
- Added boolean as type for AoRadio

# Things to Note
- Dismissible and showCallout are both needed as a way to show and hide it. Without both, it won't work. Unless I'm wrong... then suggest away!