### PR TITLE
use inherent attrs instead of props where applicable

### DIFF
--- a/src/components/AoButton.vue
+++ b/src/components/AoButton.vue
@@ -1,9 +1,7 @@
 <template>
   <button
     :type="type"
-    :form="formName"
     :class="computedButtonClass"
-    :disabled="disabled"
   >
     <slot />
   </button>
@@ -21,11 +19,6 @@ export default {
       validator: function (buttonType) {
         return ['button', 'submit'].indexOf(buttonType) !== -1
       }
-    },
-
-    formName: {
-      type: String,
-      default: null
     },
 
     small: {
@@ -69,11 +62,6 @@ export default {
     },
 
     textOnly: {
-      type: Boolean,
-      default: false
-    },
-
-    disabled: {
       type: Boolean,
       default: false
     },

--- a/src/components/AoCheckbox.vue
+++ b/src/components/AoCheckbox.vue
@@ -7,6 +7,7 @@
     >
       <input
         v-model="checked"
+        v-bind="$attrs"
         :value="checkboxValue"
         :disabled="disabled"
         type="checkbox"
@@ -22,6 +23,7 @@
 
 <script>
 export default {
+  inheritAttrs: false,
   props: {
     // both this and checkboxValue needed to avoid vue issue
     value: {

--- a/src/components/AoFileUpload.vue
+++ b/src/components/AoFileUpload.vue
@@ -10,6 +10,7 @@
       <slot name="fileUploadLabelTooltip" />
     </div>
     <input
+      v-bind="$attrs"
       :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control']"
       :name="name"
       :disabled="disabled || disableAll"
@@ -34,6 +35,7 @@
 
 <script>
 export default {
+  inheritAttrs: false,
   props: {
     label: {
       type: String,

--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -11,14 +11,12 @@
     </div>
     <div :class="['ao-input', { 'ao-input--has-addon': hasInputGroup }]">
       <input
+        v-bind="$attrs"
         :class="['ao-form-control', {'ao-form-control--invalid': invalid }, computedSize]"
-        :type="type"
-        :placeholder="placeholder"
-        :name="name"
-        :value="value"
         :disabled="disabled || disableAll"
-        :step="step"
-        :min="min"
+        :value="value"
+        :type="type"
+        :name="name"
         @input="updateValue($event.target.value)"
         @blur="emitBlur($event)"
       >
@@ -54,6 +52,7 @@
 import { filterClasses } from './utils/component_utilities.js'
 
 export default {
+  inheritAttrs: false,
   props: {
     type: {
       type: String,
@@ -84,11 +83,6 @@ export default {
       default: null
     },
 
-    placeholder: {
-      type: String,
-      default: null
-    },
-
     iconHtml: {
       type: String,
       default: null
@@ -114,11 +108,6 @@ export default {
       default: false
     },
 
-    step: {
-      type: Number,
-      default: 1
-    },
-
     invalid: {
       type: Boolean,
       default: false
@@ -139,11 +128,6 @@ export default {
 
     instructionText: {
       type: String,
-      default: null
-    },
-
-    min: {
-      type: [String, Number],
       default: null
     }
   },

--- a/src/components/AoRadio.vue
+++ b/src/components/AoRadio.vue
@@ -2,8 +2,8 @@
   <label class="ao-checkbox">
     <input
       v-model="checked"
+      v-bind="$attrs"
       :value="val"
-      :disabled="disabled"
       type="radio"
       @change="toggle"
     >
@@ -13,6 +13,7 @@
 
 <script>
 export default {
+  inheritAttrs: false,
   props: {
     // consistant naming and proxy for vue magic
     value: {
@@ -23,11 +24,6 @@ export default {
     val: {
       type: [String, Number],
       required: true
-    },
-
-    disabled: {
-      type: Boolean,
-      default: false
     },
 
     label: {

--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -1,7 +1,5 @@
 <template>
-  <table
-    :class="[computedClasses, computedVAlign]"
-  >
+  <table :class="[computedClasses, computedVAlign]">
     <thead>
       <tr>
         <th

--- a/src/components/AoTextArea.vue
+++ b/src/components/AoTextArea.vue
@@ -1,5 +1,4 @@
 <template>
-  <!-- investigate min max length -->
   <div :class="['ao-form-group', {'ao-form-group--disabled': disableAll}, {'ao-form-group--has-feedback': hasFeedbackText }]">
     <div
       v-show="showLabel"
@@ -11,13 +10,9 @@
       <slot name="tooltip" />
     </div>
     <textarea
+      v-bind="$attrs"
       :class="{'ao-form-control--invalid': invalid }"
       :value="value"
-      :placeholder="placeholder"
-      :name="name"
-      :rows="rows"
-      :maxlength="maxLength"
-      :minlength="minLength"
       :disabled="disabled || disableAll"
       class="ao-form-control"
       @input="inputEvent($event.target.value)"
@@ -40,6 +35,7 @@
 
 <script>
 export default {
+  inheritAttrs: false,
   props: {
     value: {
       type: String,
@@ -51,26 +47,6 @@ export default {
       default: null
     },
 
-    name: {
-      type: String,
-      default: null
-    },
-
-    placeholder: {
-      type: String,
-      default: null
-    },
-
-    maxLength: {
-      type: Number,
-      default: 100000
-    },
-
-    minLength: {
-      type: Number,
-      default: 0
-    },
-
     disabled: {
       type: Boolean,
       default: false
@@ -79,11 +55,6 @@ export default {
     disableAll: {
       type: Boolean,
       default: false
-    },
-
-    rows: {
-      type: Number,
-      default: 5
     },
 
     invalid: {

--- a/src/components/AoTooltip.vue
+++ b/src/components/AoTooltip.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    :class="[computedClasses, `ao-tooltip--${this.position}`]"
-  >
+  <div :class="[computedClasses, `ao-tooltip--${this.position}`]">
     <slot>
       <i class="ao-tooltip__default-icon glyphicon glyphicon-info-sign" />
     </slot>


### PR DESCRIPTION
# Link to Github Issue
https://github.com/AmpleOrganics/Blaze.vue/issues/258

# Description

The purpose of this pr is to remove clutter and use a Vue feature to pass in native html properties directly without needing to add our own custom defined props

more info can be found [here](https://vuejs.org/v2/guide/components-props.html#Disabling-Attribute-Inheritance)

note: this pr only does this for attributes(properties) and NOT events


# QA
everything should be working as needed
any props that are more complicated than mere assigning (ie. :disabled=disabled) will not be able to take advantage of this and should be left as is

Anything that was working before should be working as is (please confirm this)

only breaking change (that i am currently aware of) will be for the button component as it took in a prop called "formName" and it was bound to the html property of "form"



