### PR TITLE
Tweak and improve gray color scale

### DIFF
--- a/src/assets/styles/mixins/shared-input-styles.scss
+++ b/src/assets/styles/mixins/shared-input-styles.scss
@@ -26,7 +26,7 @@
     &[disabled],
     &[readonly] {
       background-color: $color-gray-80;
-      border-color: $color-gray-60;
+      border-color: $color-gray-70;
       opacity: 1;
     }
     &[disabled] {

--- a/src/assets/styles/settings/_variables.scss
+++ b/src/assets/styles/settings/_variables.scss
@@ -41,14 +41,14 @@ $color-destructive-dark:      $color-red-dark;
 
 // Ample Shades of Gray
 $color-gray-10:               #474a4c;
-$color-gray-20:               #585d60;
-$color-gray-30:               #818a91;
-$color-gray-40:               #aaaaaa;
-$color-gray-50:               #cccccc;
-$color-gray-60:               #dcdedf;
-$color-gray-80:               #ebecef;
+$color-gray-20:               #5e6366;
+$color-gray-30:               #757b80;
+$color-gray-40:               #8d9499;
+$color-gray-50:               #aaadb3;
+$color-gray-60:               #c6c9cc;
+$color-gray-70:               #d9dcde;
+$color-gray-80:               #ebecf0;
 $color-gray-90:               #f7f7f9;
-$color-grey-light:            #ddd;
 
 //
 // Spacing & Sizing
@@ -107,8 +107,8 @@ $header-toolbar-height:       60px;
 // General UI Styles
 //
 
-$ui-border-color-base:        $color-gray-60;
-$border-gray-50:              1px solid $color-gray-50;
+$ui-border-color-base:        $color-gray-70;
+$border-gray-50:              1px solid $color-gray-60;
 
 $border-radius-base:          3px;
 
@@ -149,5 +149,5 @@ $input-label-margin:          0 0 $spacer-xs;
 //
 
 $table-cell-padding:          $font-size-base/2;
-$table-border-color:          $color-gray-60;
+$table-border-color:          $color-gray-70;
 

--- a/src/components/AoButton.vue
+++ b/src/components/AoButton.vue
@@ -143,7 +143,7 @@ export default {
 
 /* Default styles, overridden by special classes */
  background-color: $color-white;
- border-color: $color-gray-50;
+ border-color: $color-gray-60;
  color: $font-color-base;
 
 /* Default hover/active styles, overridden by special classes */
@@ -153,7 +153,7 @@ export default {
 
  &:active, &:hover:not([disabled]) {
    background-color: darken($color-white, 3%);
-   border-color: darken($color-gray-50, 3%);
+   border-color: darken($color-gray-60, 3%);
    color: darken($font-color-base, 3%);
  }
 
@@ -184,7 +184,7 @@ export default {
  }
 
  &--subtle {
-   @include ao-button-colors($font-color-base, $color-gray-90, $color-gray-60, 5%);
+   @include ao-button-colors($font-color-base, $color-gray-90, $color-gray-70, 5%);
  }
 
  &--naked {

--- a/src/components/AoModal.vue
+++ b/src/components/AoModal.vue
@@ -165,7 +165,7 @@ export default {
   &__footer {
     padding: $spacer;
     text-align: right;
-    border-top: 1px solid $color-gray-60;
+    border-top: 1px solid $color-gray-70;
   }
 
   &--large &__content {

--- a/src/components/AoPaginate.vue
+++ b/src/components/AoPaginate.vue
@@ -85,7 +85,7 @@ export default {
       opacity: 0.65;
       filter: alpha(opacity=65);
       box-shadow: none;
-      color: $color-gray-50;
+      color: $color-gray-60;
       background: $color-white !important;
       z-index: $zindex-base - 1;
     }

--- a/src/components/AoRadioButtonGroup.vue
+++ b/src/components/AoRadioButtonGroup.vue
@@ -94,7 +94,7 @@ export default {
     box-shadow: $shadow-subtle;
     cursor: pointer;
     background-color: $color-white;
-    border-color: $color-gray-50;
+    border-color: $color-gray-60;
     color: $font-color-base;
   }
 
@@ -116,14 +116,14 @@ export default {
     &:focus + &-label {
       box-shadow: $shadow-inset;
       background-color: darken($color-white, 3%);
-      border-color: darken($color-gray-50, 3%);
+      border-color: darken($color-gray-60, 3%);
       color: darken($font-color-base, 3%);
     }
 
     &:disabled + &-label {
       background-color: $color-white !important;
-      border-color: $color-gray-50 !important;
-      color: $color-gray-40 !important;
+      border-color: $color-gray-60 !important;
+      color: $color-gray-50 !important;
       cursor: not-allowed !important;
     }
 

--- a/src/components/AoSectionHeader.vue
+++ b/src/components/AoSectionHeader.vue
@@ -60,7 +60,7 @@ export default {
 
 .ao-section-header {
   background-color: $color-white;
-  border: 1px solid $color-gray-60;
+  border: 1px solid $color-gray-70;
   border-radius: $border-radius-base;
   padding: $spacer;
   margin-bottom: $spacer;

--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -158,7 +158,7 @@ $table-row-background-shaded: $color-gray-90;
   min-height: 0.01%;
 
   tr {
-    border-bottom: 1px solid $color-gray-60;
+    border-bottom: 1px solid $color-gray-70;
   }
 
   th, td {

--- a/src/components/AoTooltip.vue
+++ b/src/components/AoTooltip.vue
@@ -90,7 +90,7 @@ $tooltip-transition: opacity .2s ease-in-out;
   }
 
   &__default-icon {
-    color: $color-gray-40;
+    color: $color-gray-50;
     font-size: $font-size-sm;
   }
 


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/264

# Description

I am working on syncing up CSS between blaze and webapp. As such I need to get them both on the same color system, and this will help establish a better standard.

- all gray colors adjusted to have 210 degree hue with a gradual increase in saturation from 1% (lightest) to 7% (darkest. Pretty much indescernible difference, getting nitpicky here
- `color-gray-30` changed to `color-gray-40`
- `color-gray-50` changed to `color-gray-60`
- `color-gray-60` changed to `color-gray-70`
- new color `color-gray-30` to complete the scale