### PR TITLE
272 - AoSelect - Add boolean to value prop validation

### DIFF
--- a/docs/components/Select.js
+++ b/docs/components/Select.js
@@ -25,7 +25,7 @@ data () {
   }
 }`,
   apiRows: [
-    { name: 'value', type: 'String', default: 'null', description: 'This prop defines the selected value.' },
+    { name: 'value', type: 'String, Number, Boolean', default: 'null', description: 'This prop defines the selected value.' },
     { name: 'label', type: 'String, required', default: 'null', description: 'This prop defines the label of the select.' },
     { name: 'showLabel', type: 'Boolean', default: 'true', description: 'This prop defines if the select label will be shown or not.' },
     { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },

--- a/src/components/AoSelect.vue
+++ b/src/components/AoSelect.vue
@@ -49,7 +49,7 @@ import { filterClasses } from './utils/component_utilities.js'
 export default {
   props: {
     value: {
-      type: [String, Number],
+      type: [String, Number, Boolean],
       default: null
     },
 


### PR DESCRIPTION
# Link to Github Issue
[272](https://github.com/AmpleOrganics/Blaze.vue/issues/272)

# Description

Added boolean to value prop validation so an error isn't thrown if a boolean value is selected