### PR TITLE
Add ability to right align and hide table headers

### DIFF
--- a/docs/components/Table.js
+++ b/docs/components/Table.js
@@ -2,7 +2,7 @@ export default {
   header: 'Table',
   description: 'This is a customizable table component.',
   snippet:
-        `<ao-table
+`<ao-table
   :headers="headers"
   :is-clickable="isClickable"
   :show-no-data-text="showNoDataText"
@@ -22,11 +22,10 @@ export default {
 
 data () {
   return {
-    ...TableDocumentation,
     headers: [
       { field: 'id', title: 'ID', sortable: true },
-      { field: 'first_name', title: 'First Name', sortable: true },
-      { field: 'last_name', title: 'Last Name', sortable: true }
+      { field: 'first_name', title: 'First Name', sortable: true, hidden: true },
+      { field: 'last_name', title: 'Last Name', sortable: true, alignRight: true }
     ],
     users: [
       { 'id': 1, 'first_name': 'Jesse', 'last_name': 'Simmons' },
@@ -60,6 +59,7 @@ methods: {
   apiRows: [
     { name: 'condensed', type: 'Boolean', default: 'false', description: 'When set to true, this prop reduces appropriate styling to make table look condensed.' },
     { name: 'headers', type: 'Array', default: 'null', description: 'This prop contains an array of objects with header title, field and a sortable boolean to determine if your data should be sorted by that header.' },
+    { name: 'header props', type: 'Boolean', default: 'false', description: '\'alignRight\' aligns the header to the right side of the space givin and \'hidden\' hides a given th header' },
     { name: 'isClickable', type: 'Boolean', default: 'false', description: 'When set to true, this prop adds appropriate styling to signify that the table and table rows are clickable.' },
     { name: 'noDataText', type: 'String', default: '', description: 'Text to show when table has no data.' },
     { name: 'order', type: 'String ("asc" or "desc")', default: 'desc', description: 'This prop defines which order (ascending or decending) is the default.' },

--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -79,8 +79,8 @@ export default {
       ...TableDocumentation,
       headers: [
         { field: 'id', title: 'ID', sortable: true },
-        { field: 'first_name', title: 'First Name', sortable: true },
-        { field: 'last_name', title: 'Last Name', sortable: true }
+        { field: 'first_name', title: 'First Name', sortable: true, hidden: true },
+        { field: 'last_name', title: 'Last Name', sortable: true, alignRight: true }
       ],
       users: [
         { 'id': 1, 'first_name': 'Jesse', 'last_name': 'Simmons' },
@@ -101,11 +101,13 @@ export default {
       noDataText: 'No Data'
     }
   },
+
   computed: {
     filteredUsers () {
       return this.showNoDataText ? [] : this.users
     }
   },
+
   methods: {
     sortTable (sortBy, order) {
       this.users = orderBy(this.users, sortBy, order)

--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -5,11 +5,14 @@
         <th
           v-for="columnHeader in headers"
           :key="columnHeader.field"
-          :class="isSortableClass(columnHeader.sortable)"
-          @click="sortByHeader(columnHeader.field, columnHeader.sortable)"
+          :class="['ao-table__header', isSortableClass(columnHeader.sortable), {'ao-table__header--text-right' : columnHeader.alignRight}]"
         >
-          <span class="ao-table__header">
-            {{ columnHeader.title }}<span :class="isChevroned(columnHeader.field, columnHeader.sortable)" />
+          <span
+            v-show="!columnHeader.hidden"
+            class="ao-table__header-text"
+            @click="sortByHeader(columnHeader.field, columnHeader.sortable, columnHeader.hidden)"
+          >
+            {{ columnHeader.title }}<span :class="isChevroned(columnHeader.field, columnHeader.sortable, columnHeader.hidden)" />
           </span>
         </th>
       </tr>
@@ -111,9 +114,8 @@ export default {
   },
 
   methods: {
-    sortByHeader (header, sortable) {
-      // undefined is used so you do not have to set searchable
-      if (sortable === true || sortable === undefined) {
+    sortByHeader (header, sortable = true, hidden = false) {
+      if (this.isSortable(sortable, hidden)) {
         if (header === this.lastSelectedHeader) {
           this.orderProxy = this.toggleOrder(this.orderProxy)
         } else {
@@ -125,18 +127,22 @@ export default {
       }
     },
 
-    isSortableClass (sortable) {
-      return sortable === true || sortable === undefined ? 'ao-table__th--sortable' : null
+    isSortableClass (sortable = true, hidden = false) {
+      return this.isSortable(sortable, hidden) ? 'ao-table__th--sortable' : null
     },
 
-    isChevroned (name, sortable) {
-      if (name === this.sortProxy && (sortable === true || sortable === undefined)) {
+    isChevroned (name, sortable = true, hidden = false) {
+      if (name === this.sortProxy && this.isSortable(sortable, hidden)) {
         return this.orderProxy === 'desc' ? 'glyphicon glyphicon-chevron-down ao-table__sort-icon' : 'glyphicon glyphicon-chevron-up ao-table__sort-icon'
       }
     },
 
     toggleOrder (order) {
       return order === 'asc' ? 'desc' : 'asc'
+    },
+
+    isSortable (sortable, hidden) {
+      return sortable === true && hidden === false
     }
   }
 }
@@ -165,9 +171,22 @@ $table-row-background-shaded: $color-gray-90;
     padding: $table-cell-padding;
   }
 
+  &__th--sortable > span {
+    cursor: pointer;
+    border-bottom: 1px dotted $color-gray-10;
+  }
+
   th {
     font-weight: $font-weight-bold;
     text-align: left;
+
+    &.ao-table__header--text-right {
+      text-align: right;
+    }
+
+    &.ao-table__header--hidden > span {
+      display: none;
+    }
   }
 
   &--condensed {
@@ -218,11 +237,6 @@ $table-row-background-shaded: $color-gray-90;
 
   & tfoot tr > td {
     border-top-width: 2px;
-  }
-
-  &__th--sortable > span {
-    cursor: pointer;
-    border-bottom: 1px dotted $color-gray-10;
   }
 
   &__sort-icon {

--- a/tests/unit/AoTable.spec.js
+++ b/tests/unit/AoTable.spec.js
@@ -58,7 +58,7 @@ describe('Table', () => {
       propsData: {
         headers: [
           { field: 'id', title: 'ID' },
-          { field: 'first_name', title: 'First Name' },
+          { field: 'first_name', title: 'First Name', hidden: false },
           { field: 'last_name', title: 'Last Name' },
           { field: 'gender', title: 'Gender' }
         ]
@@ -68,6 +68,7 @@ describe('Table', () => {
       table
         .findAll('th')
         .at(1)
+        .find('span')
         .trigger('click')
 
     triggerSort()
@@ -83,11 +84,52 @@ describe('Table', () => {
     table.setProps({
       headers: [
         { field: 'id', title: 'ID', sortable: false },
-        { field: 'first_name', title: 'First Name', sortable: false }
+        { field: 'first_name', title: 'First Name', sortable: false, hidden: false }
       ]
     })
     triggerSort()
-    expect(table.emitted().sortTable.length).toBe(3)
+
+    table.setProps({
+      headers: [
+        { field: 'id', title: 'ID', sortable: false },
+        { field: 'first_name', title: 'First Name', sortable: true, hidden: false }
+      ]
+    })
+    triggerSort()
+
+    table.setProps({
+      headers: [
+        { field: 'id', title: 'ID', sortable: false },
+        { field: 'first_name', title: 'First Name', sortable: false, hidden: true }
+      ]
+    })
+    triggerSort()
+
+    table.setProps({
+      headers: [
+        { field: 'id', title: 'ID', sortable: false },
+        { field: 'first_name', title: 'First Name', hidden: true }
+      ]
+    })
+    triggerSort()
+
+    table.setProps({
+      headers: [
+        { field: 'id', title: 'ID', sortable: false },
+        { field: 'first_name', title: 'First Name' }
+      ]
+    })
+    triggerSort()
+
+    table.setProps({
+      headers: [
+        { field: 'id', title: 'ID', sortable: false },
+        { field: 'first_name', title: 'First Name', sortable: true, hidden: true }
+      ]
+    })
+    triggerSort()
+
+    expect(table.emitted().sortTable.length).toBe(5)
   })
 
   it('nodata', () => {
@@ -111,5 +153,61 @@ describe('Table', () => {
 
     table.setProps({ showNoDataText: true, noDataText: 'test' })
     expect(table.find(noDataSelector).text()).toBe('test')
+  })
+
+  it('aligns header to right side when populated', () => {
+    const table = mount(Table, {
+      propsData: {
+        headers: [
+          { field: 'id', title: 'ID', alignRight: true },
+          { field: 'first_name', title: 'First Name' },
+          { field: 'last_name', title: 'Last Name' },
+          { field: 'gender', title: 'Gender' }
+        ]
+      }
+    })
+
+    expect(
+      table
+        .findAll('.ao-table__header')
+        .at(0)
+        .classes()
+    ).toContain('ao-table__header--text-right')
+
+    expect(
+      table
+        .findAll('.ao-table__header')
+        .at(1)
+        .classes()
+    ).not.toContain('ao-table__header--text-right')
+  })
+
+  it('hides header if hidden attribute is added', () => {
+    const table = mount(Table, {
+      propsData: {
+        headers: [
+          { field: 'id', title: 'ID', hidden: true },
+          { field: 'first_name', title: 'First Name' },
+          { field: 'last_name', title: 'Last Name' },
+          { field: 'gender', title: 'Gender' }
+        ]
+      }
+    })
+
+    expect(
+      table
+        .findAll('.ao-table__header')
+        .at(0)
+        .find('.ao-table__header-text')
+        .isVisible()
+    ).toBe(false)
+
+    expect(
+      table
+        .findAll('.ao-table__header')
+        .at(1)
+        .find('.ao-table__header-text')
+        .isVisible()
+    ).toBe(true)
   })
 })


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/277

# Description

Gives ability to:
- right-align table header
- hide table header text accessibly

# To Do
- [x] update `AoTable` documentation with new `alignRight` and `hidden`  header params
- [X] update `AoTable` unit test with new header params

Note: was having serious reactivity issues with trying to make the alignProp and hidden header props to the playground part of the docs. if anyone has a solution let me know