### PR TITLE
AoTable: Add toggle for new headers props, update wording

### DIFF
--- a/docs/components/Table.js
+++ b/docs/components/Table.js
@@ -2,7 +2,8 @@ export default {
   header: 'Table',
   description: 'This is a customizable table component.',
   snippet:
-`<ao-table
+`
+<ao-table
   :headers="headers"
   :is-clickable="isClickable"
   :show-no-data-text="showNoDataText"
@@ -59,7 +60,7 @@ methods: {
   apiRows: [
     { name: 'condensed', type: 'Boolean', default: 'false', description: 'When set to true, this prop reduces appropriate styling to make table look condensed.' },
     { name: 'headers', type: 'Array', default: 'null', description: 'This prop contains an array of objects with header title, field and a sortable boolean to determine if your data should be sorted by that header.' },
-    { name: 'header props', type: 'Boolean', default: 'false', description: '\'alignRight\' aligns the header to the right side of the space givin and \'hidden\' hides a given th header' },
+    { name: 'headers > alignRight,<br /> hidden', type: 'Boolean', default: 'false', description: 'Include the <strong>alignRight</strong> property to align the header to the right side of the space given. <br />Include a <strong>hidden</strong> property to hide a given \'th\' header.' },
     { name: 'isClickable', type: 'Boolean', default: 'false', description: 'When set to true, this prop adds appropriate styling to signify that the table and table rows are clickable.' },
     { name: 'noDataText', type: 'String', default: '', description: 'Text to show when table has no data.' },
     { name: 'order', type: 'String ("asc" or "desc")', default: 'desc', description: 'This prop defines which order (ascending or decending) is the default.' },

--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -38,6 +38,24 @@
       <div class="component-controls">
         <div class="component-controls__group">
           <ao-checkbox
+            v-model="hidden"
+            :checkbox-value="false"
+            checkbox-label="hidden (First Name column)"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="alignRight"
+            :checkbox-value="false"
+            checkbox-label="alignRight (Last Name column)"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-checkbox
             v-model="showNoDataText"
             :checkbox-value="false"
             checkbox-label="showNoDataText"
@@ -77,11 +95,6 @@ export default {
   data () {
     return {
       ...TableDocumentation,
-      headers: [
-        { field: 'id', title: 'ID', sortable: true },
-        { field: 'first_name', title: 'First Name', sortable: true, hidden: true },
-        { field: 'last_name', title: 'Last Name', sortable: true, alignRight: true }
-      ],
       users: [
         { 'id': 1, 'first_name': 'Jesse', 'last_name': 'Simmons' },
         { 'id': 2, 'first_name': 'John', 'last_name': 'Jacobs' },
@@ -97,6 +110,8 @@ export default {
       sortBy: 'id',
       order: 'asc',
       isClickable: true,
+      alignRight: true,
+      hidden: true,
       showNoDataText: false,
       noDataText: 'No Data'
     }
@@ -105,6 +120,13 @@ export default {
   computed: {
     filteredUsers () {
       return this.showNoDataText ? [] : this.users
+    },
+    headers () {
+      return [
+        { field: 'id', title: 'ID', sortable: true },
+        { field: 'first_name', title: 'First Name', sortable: true, hidden: this.hidden },
+        { field: 'last_name', title: 'Last Name', sortable: true, alignRight: this.alignRight }
+      ]
     }
   },
 

--- a/docs/components/TableCell.js
+++ b/docs/components/TableCell.js
@@ -2,23 +2,25 @@ export default {
   header: 'Table Cell',
   description: 'This styles and sizes inputs and buttons consistently.',
   snippet:
-`<ao-table-cell content="button" >
-      <ao-tooltip text="Archive">
-        <ao-button>
-          <i class="md-icon__archive" />
-        </ao-button>
-      </ao-tooltip>
-      <ao-tooltip text="Download PDF">
-        <ao-button>
-          <i class="md-icon__get_app" />
-        </ao-button>
-      </ao-tooltip>
-      <ao-tooltip text="Actions">
-        <ao-button>
-          <i class="md-icon__more_horiz" />
-        </ao-button>
-      </ao-tooltip>
-    </ao-table-cell>`,
+`
+<ao-table-cell content="button" >
+  <ao-tooltip text="Archive">
+    <ao-button>
+      <i class="md-icon__archive" />
+    </ao-button>
+  </ao-tooltip>
+  <ao-tooltip text="Download PDF">
+    <ao-button>
+      <i class="md-icon__get_app" />
+    </ao-button>
+  </ao-tooltip>
+  <ao-tooltip text="Actions">
+    <ao-button>
+      <i class="md-icon__more_horiz" />
+    </ao-button>
+  </ao-tooltip>
+</ao-table-cell>
+    `,
   apiRows: [
     { name: 'content', type: 'String', default: 'null', description: 'This prop will style either a button or an input appropriately.' },
     { name: 'alignRight', type: 'Boolean', default: 'false', description: 'This prop will align the text in the table cell to the right.' }

--- a/docs/helpers/ApiTable.vue
+++ b/docs/helpers/ApiTable.vue
@@ -7,10 +7,10 @@
       v-for="(row, index) in rows"
       :key="index"
     >
-      <td>{{ row.name }}</td>
+      <td v-html="row.name" />
       <td>{{ row.type }}</td>
       <td>{{ row.default }}</td>
-      <td>{{ row.description }}</td>
+      <td v-html="row.description" />
     </tr>
   </ao-table>
   <div v-else>


### PR DESCRIPTION
# Description

This PR has a few suggestions on improving some styling and wording. I found that the 'alignRight' and 'hidden' properties for the table headers wasn't very clear, so I've added some toggling to the example to hopefully help demonstrate the functionality a bit more clearly.

![toggleblaze](https://user-images.githubusercontent.com/11099008/52493568-ccf35300-2b99-11e9-8d61-8111c76da65c.gif)

Also updated the description of these new properties in the docs. Since these aren't true 'props', I tried to differentiate them a bit by writing them as 
```
headers >
alignRight
hidden
```