### PR TITLE
Add ability to close alerts before the 4 second timout

### DIFF
--- a/docs/components/Alert.vue
+++ b/docs/components/Alert.vue
@@ -8,7 +8,7 @@
       <div class="component-example component-example__alert">
         <ao-alert
           v-if="showAlert"
-          :show-alert="showAlert"
+          :show-alert.sync="showAlert"
           :destructive="activateProp('destructive')"
           :caution="activateProp('caution')"
           :icon-class="'md-icon__check'"
@@ -39,11 +39,9 @@
           </ao-select>
         </div>
         <div class="component-controls__group">
-          <ao-checkbox
-            v-model="showAlert"
-            :checkbox-value="true"
-            checkbox-label="showAlert"
-          />
+          <ao-button @click.native="displayAlert">
+            Display Alert
+          </ao-button>
         </div>
       </div>
     </div>
@@ -82,6 +80,9 @@ export default {
   methods: {
     activateProp (compare) {
       return compare === this.selectedType
+    },
+    displayAlert () {
+      this.showAlert = true
     }
   }
 }

--- a/src/components/AoAlert.vue
+++ b/src/components/AoAlert.vue
@@ -10,6 +10,13 @@
       <div class="ao-alert__message">
         <slot />
       </div>
+      <div class="ao-alert__dismiss">
+        <button
+          @click="closeAlert"
+        >
+          <i class="md-icon__close" />
+        </button>
+      </div>
     </div>
   </transition>
 </template>
@@ -59,9 +66,13 @@ export default {
   methods: {
     autoCloseAlert () {
       setTimeout(() => {
-        this.$emit('update:showAlert', false)
+        this.closeAlert()
       }, 4000)
+    },
+    closeAlert () {
+      this.$emit('update:showAlert', false)
     }
+
   }
 }
 </script>
@@ -106,6 +117,26 @@ $ao-alert-height: 3.75rem;
     &--caution {
       background-color: $color-caution;
     }
+  }
+
+  &__dismiss {
+    display: flex;
+      flex-direction: column;
+
+      button {
+        background: transparent;
+        border: 0;
+        height: auto;
+        width: auto;
+        flex-grow: 0;
+        opacity: .6;
+        font-size: $font-size-sm;
+        padding: 0.5rem;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
   }
 }
 </style>

--- a/tests/unit/AoAlert.spec.js
+++ b/tests/unit/AoAlert.spec.js
@@ -55,4 +55,15 @@ describe('Alert', () => {
     jest.runAllTimers()
     expect(alert.emitted()['update:showAlert']).toBeTruthy()
   })
+
+  it('is dismissible', () => {
+    const alert = mount(Alert, {
+      propsData: {
+        showAlert: true
+      }
+    })
+    expect(alert.contains('ao-alert__dismiss'))
+    alert.find('.ao-alert__dismiss button').trigger('click')
+    expect(alert.emitted()['update:showAlert']).toBeTruthy()
+  })
 })


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/286

# Description

Allows the user to dismiss the alert before the 4s timeout, for situations where it may be covering another element.
Also updates the docs to allow the timeout and close behaviour to be demonstrated.