### PR TITLE
Move AoModal above AoAlert on the z-index

### DIFF
--- a/src/assets/styles/settings/_variables.scss
+++ b/src/assets/styles/settings/_variables.scss
@@ -97,9 +97,9 @@ $layout-background-color:     $color-gray-90;
 $zindex-base:                 1000;
 $zindex-dropdown:             1010;
 $zindex-header-toolbar:       1020;
-$zindex-modal-backdrop:       1030;
-$zindex-modal:                1031;
-$zindex-alert:                1040;
+$zindex-alert:                1030;
+$zindex-modal-backdrop:       1040;
+$zindex-modal:                1041;
 $zindex-spinner:              1050;
 $zindex-tooltip:              1060;
 


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/281

# Description

Moves `ao-modal` above `ao-alert` on the z-index.
"Currently alerts block modal content, which is worse than modals blocking alert content."