### PR TITLE
Change AoRadio root css class to ao-radio

### DIFF
--- a/src/components/AoRadio.vue
+++ b/src/components/AoRadio.vue
@@ -1,5 +1,5 @@
 <template>
-  <label class="ao-checkbox">
+  <label class="ao-radio">
     <input
       v-model="checked"
       v-bind="$attrs"
@@ -67,7 +67,7 @@ export default {
 </script>
 
 <style lang="scss">
-.ao-checkbox {
+.ao-radio {
   &:not(:last-of-type) {
     margin-right: $spacer-sm;
   }

--- a/tests/unit/AoRadio.spec.js
+++ b/tests/unit/AoRadio.spec.js
@@ -11,7 +11,7 @@ describe('Radio', () => {
         label: 'label'
       }
     })
-    expect(radio.classes()).toContain('ao-checkbox')
+    expect(radio.classes()).toContain('ao-radio')
   })
 
   it('disabled', () => {


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/213

# Description

AoRadio was using the css for ao-checkbox.