### PR TITLE
AoDatePicker component that allows users to type or use pick date picker

### DIFF
--- a/docs/components/DatePicker.js
+++ b/docs/components/DatePicker.js
@@ -1,0 +1,32 @@
+export default {
+  header: 'DatePicker',
+  description: 'This is a customizable date picker component.',
+  snippet:
+  `<ao-date-picker
+  v-model="selectedDate"
+  :label="label"
+  :placeholder="placeholder"
+  :show-label="showLabel"
+  :icon-class="iconClass"
+  :is-icon-clickable="true"
+  :icon-html="iconHtml"
+  :disabled="disabled"
+  :disable-all="disableAll"
+  :invalid="invalid"
+  :invalid-message="invalidMessage"
+  :instruction-text="instructionText"
+/>`,
+  apiRows: [
+    { name: 'value', type: 'String', default: 'null', description: 'Defines the value of the date picker.' },
+    { name: 'label', type: 'String, required', default: '-', description: 'Displays the text label above the date picker.' },
+    { name: 'showLabel', type: 'Boolean', default: 'true', description: 'Hide or unhide the text label.' },
+    { name: 'name', type: 'String', default: 'null', description: 'Defines the html name property and has no functional purpose on its own.' },
+    { name: 'placeholder', type: 'String', default: 'null', description: 'Defines the placeholder text inside of the date picker.' },
+    { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' },
+    { name: 'disableAll', type: 'Boolean', default: 'false', description: 'Disables interaction with the component, greys out label and instruction text.' },
+    { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the date picker.' },
+    { name: 'invalid', type: 'Boolean', default: 'false', description: 'Adds a class to display a red border around the component to indicate an invalid entry.' },
+    { name: 'invalidMessage', type: 'String', default: 'null', description: 'Adds invalid messages below date picker' },
+    { name: 'size', type: 'String (null or small)', default: 'null', description: 'Pass in \'small\' to decrease the size of the date picker field.' }
+  ]
+}

--- a/docs/components/DatePicker.vue
+++ b/docs/components/DatePicker.vue
@@ -5,38 +5,47 @@
     </template>
 
     <div slot="example">
-      <h3>Text Input Example</h3>
+      <h3>Date Picker Example</h3>
       <div class="component-example">
-        <ao-input
-          :label="textLabel"
-          :placeholder="textPlaceholder"
+        <ao-date-picker
+          v-model="selectedDate"
+          :label="label"
+          :placeholder="placeholder"
           :show-label="showLabel"
+          :icon-class="iconClass"
+          :is-icon-clickable="true"
           :icon-html="iconHtml"
           :disabled="disabled"
           :disable-all="disableAll"
           :invalid="invalid"
           :invalid-message="invalidMessage"
           :instruction-text="instructionText"
-          :min="minDate"
-          :is-icon-clickable="isIconClickable"
-          @icon-clicked="onIconClicked"
         />
       </div>
       <div class="component-controls">
         <div class="component-controls__group">
           <ao-input
-            v-model="textLabel"
+            v-model="label"
             :type="'text'"
-            :label="'Input Label Text'"
+            :label="'Label Text'"
           />
         </div>
       </div>
       <div class="component-controls">
         <div class="component-controls__group">
           <ao-input
-            v-model="textPlaceholder"
+            v-model="placeholder"
             :type="'text'"
             :label="'Placeholder Text'"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="iconClass"
+            :type="'text'"
+            :label="'iconClass'"
           />
         </div>
       </div>
@@ -76,13 +85,6 @@
       </div>
       <div class="component-controls__group">
         <ao-checkbox
-          v-model="isIconClickable"
-          :checkbox-value="true"
-          checkbox-label="isIconClickable"
-        />
-      </div>
-      <div class="component-controls__group">
-        <ao-checkbox
           v-model="disabled"
           :checkbox-value="false"
           checkbox-label="disabled"
@@ -102,72 +104,6 @@
           checkbox-label="invalid"
         />
       </div>
-      <h3 class="component-sub-example">
-        Number Input Example
-      </h3>
-      <div class="component-example">
-        <ao-input
-          :label="numberLabel"
-          :step="step"
-          :add-on="addOn"
-          type="number"
-        />
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="numberLabel"
-            :type="'text'"
-            :label="'Input Label Text'"
-          />
-        </div>
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="step"
-            :type="'number'"
-            :label="'Step Amount'"
-          />
-        </div>
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="addOn"
-            :type="'text'"
-            :label="'addOn'"
-          />
-        </div>
-      </div>
-      <h3 class="component-sub-example">
-        Date Input Example
-      </h3>
-      <div class="component-example">
-        <ao-input
-          :label="dateLabel"
-          :min="minDate"
-          type="date"
-        />
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="dateLabel"
-            :type="'text'"
-            :label="'Input Label Text'"
-          />
-        </div>
-      </div>
-      <div class="component-controls">
-        <div class="component-controls__group">
-          <ao-input
-            v-model="minDate"
-            :type="'date'"
-            :label="'Min Date'"
-          />
-        </div>
-      </div>
     </div>
     <template slot="snippet">
       {{ snippet }}
@@ -181,7 +117,7 @@
 <script>
 import Layout from '../layout/Layout'
 import ApiTable from '../helpers/ApiTable'
-import InputDocumentation from './Input'
+import DatePickerDocumentation from './DatePicker'
 
 export default {
   components: {
@@ -190,27 +126,23 @@ export default {
   },
   data () {
     return {
-      ...InputDocumentation,
-      textLabel: 'Enter your name',
-      textPlaceholder: 'e.g. Tandy Miller',
+      ...DatePickerDocumentation,
+      selectedDate: null,
+      label: 'Selected Date',
+      placeholder: 'YYYY-MM-DD',
       showLabel: true,
-      iconHtml: '&#10004;',
-      addOn: 'years',
+      iconHtml: null,
+      iconClass: 'md-icon__date_range',
       disabled: false,
       disableAll: false,
       invalid: false,
-      numberLabel: 'Enter your age',
-      step: 1,
-      dateLabel: 'Enter your date of birth',
       invalidMessage: 'INVALID!',
-      instructionText: 'Must be 16 characters',
-      minDate: null,
-      isIconClickable: false
+      instructionText: 'Format: YYYY-MM-DD'
     }
   },
   methods: {
     onIconClicked () {
-      alert('icon clicked')
+      console.log('icon clicked')
     }
   }
 }

--- a/docs/components/Input.js
+++ b/docs/components/Input.js
@@ -3,11 +3,18 @@ export default {
   description: 'This is a customizable input component.',
   snippet:
         `<ao-input
-  type="text"
-  :label="'Enter your name'"
-  :placeholder="'e.g. Tandy Miller'"
-  :show-label="true"
-  :icon-html="'&#10004;'"
+  :label="textLabel"
+  :placeholder="textPlaceholder"
+  :show-label="showLabel"
+  :icon-html="iconHtml"
+  :disabled="disabled"
+  :disable-all="disableAll"
+  :invalid="invalid"
+  :invalid-message="invalidMessage"
+  :instruction-text="instructionText"
+  :min="minDate"
+  :is-icon-clickable="isIconClickable"
+  @icon-clicked="onIconClicked"
 />
 
 <ao-input
@@ -30,6 +37,7 @@ export default {
     { name: 'placeholder', type: 'String', default: 'null', description: 'Defines the placeholder text inside of the input.' },
     { name: 'iconHtml', type: 'String', default: 'null', description: 'Accepts html elements or html codes for icons.' },
     { name: 'iconClass', type: 'String', default: 'null', description: 'Accepts icon class components e.g. material icons.' },
+    { name: 'isIconClickable', type: 'Boolean', default: 'false', description: 'Makes icon clickable or non-clickable.' },
     { name: 'addOn', type: 'String', default: 'null', description: 'Appends text to the input.' },
     { name: 'step', type: 'Number', default: '1', description: 'Valid for input type "number". Defines the amount of changes per click.' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' },

--- a/src/assets/styles/settings/_blazevariables.scss
+++ b/src/assets/styles/settings/_blazevariables.scss
@@ -20,6 +20,10 @@ $md-icon-font-size-base: 18px;
   @include material-icon('arrow_drop_up');
 }
 
+.md-icon__date_range {
+  @include material-icon('date_range');
+}
+
 .md-icon__check {
   @include material-icon('check');
 }

--- a/src/blaze-plugin.js
+++ b/src/blaze-plugin.js
@@ -11,6 +11,7 @@ import AoFileUpload from './components/AoFileUpload.vue'
 import AoHeaderToolbar from './components/AoHeaderToolbar.vue'
 import AoInfoPair from './components/AoInfoPair.vue'
 import AoInput from './components/AoInput.vue'
+import AoDatePicker from './components/AoDatePicker/AoDatePicker.vue'
 import AoModal from './components/AoModal.vue'
 import AoNavbar from './components/AoNavbar.vue'
 import AoPaginate from './components/AoPaginate.vue'
@@ -40,6 +41,7 @@ const Blaze = {
     Vue.component('AoHeaderToolbar', AoHeaderToolbar)
     Vue.component('AoInfoPair', AoInfoPair)
     Vue.component('AoInput', AoInput)
+    Vue.component('AoDatePicker', AoDatePicker)
     Vue.component('AoModal', AoModal)
     Vue.component('AoNavbar', AoNavbar)
     Vue.component('AoPaginate', AoPaginate)

--- a/src/components/AoDatePicker/AoDatePicker.vue
+++ b/src/components/AoDatePicker/AoDatePicker.vue
@@ -1,0 +1,203 @@
+<template>
+  <div v-click-outside="hideCalendar">
+    <div class="ao-datepicker">
+      <ao-input
+        v-bind="$attrs"
+        type="text"
+        :value="value"
+        :label="label"
+        :show-label="showLabel"
+        :name="name"
+        icon-class="md-icon__date_range"
+        :add-on="addOn"
+        :disabled="disabled"
+        :disable-all="disableAll"
+        :invalid="invalid"
+        :invalid-message="invalidMessage"
+        :size="size"
+        :instruction-text="instructionText"
+        :is-icon-clickable="true"
+        @icon-clicked="toggleCalendar"
+        @change="emitChange"
+        @input="emitInput"
+        @blur="emitBlur"
+        @focus="emitFocus"
+      >
+        <ao-date-picker-calendar
+          v-if="calendarVisible"
+          slot="below-input"
+          :input-date="value"
+          :month-names="monthNames"
+          :day-names="dayNames"
+          class="ao-datepicker__calendar"
+          @selected="onSelected"
+        />
+      </ao-input>
+    </div>
+  </div>
+</template>
+
+<script>
+import AoInput from '../AoInput'
+import AoDatePickerCalendar from './AoDatePickerCalendar'
+import ClickOutside from '../../directives/click-outside.js'
+
+export default {
+  components: {
+    AoInput,
+    AoDatePickerCalendar
+  },
+
+  directives: {
+    ClickOutside
+  },
+
+  inheritAttrs: false,
+
+  props: {
+    value: {
+      type: [String],
+      default: null
+    },
+
+    label: {
+      type: String,
+      required: true
+    },
+
+    showLabel: {
+      type: Boolean,
+      default: true
+    },
+
+    name: {
+      type: String,
+      default: null
+    },
+
+    addOn: {
+      type: String,
+      default: null
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+
+    disableAll: {
+      type: Boolean,
+      default: false
+    },
+
+    invalid: {
+      type: Boolean,
+      default: false
+    },
+
+    invalidMessage: {
+      type: String,
+      default: null
+    },
+
+    size: {
+      type: String,
+      default: null
+    },
+
+    instructionText: {
+      type: String,
+      default: null
+    },
+
+    monthNames: {
+      type: Array,
+      default: () => (['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'])
+    },
+
+    dayNames: {
+      type: Array,
+      default: () => (['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'])
+    }
+  },
+
+  data () {
+    return {
+      calendarVisible: false
+    }
+  },
+
+  methods: {
+    toggleCalendar () {
+      this.calendarVisible = !this.calendarVisible
+    },
+
+    onSelected (date) {
+      this.calendarVisible = false
+      this.emitInput(date)
+    },
+
+    emitInput (value) {
+      this.$emit('input', value)
+    },
+
+    emitBlur (event) {
+      this.$emit('blur', event)
+    },
+
+    emitFocus (event) {
+      this.$emit('focus', event)
+    },
+
+    emitChange (value) {
+      this.$emit('change', value)
+    },
+
+    hideCalendar () {
+      this.calendarVisible = false
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+
+.ao-datepicker {
+  position: relative;
+}
+
+/* Hacky CSS approach to styling the 'input addon' per spec */
+.ao-datepicker .ao-input--has-addon {
+  display: block;
+  position: relative;
+
+  .ao-form-control:first-child {
+    border-bottom-right-radius: $border-radius-base;
+    border-top-right-radius: $border-radius-base;
+  }
+
+  & > .ao-input__addon {
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    min-width: $input-height-base;
+    top: 0;
+    right: 0;
+    border: 0;
+    background-color: transparent;
+    font-size: $font-size-lg;
+    line-height: 1;
+    color: $color-gray-40;
+
+    &:hover {
+      color: $color-gray-10;
+    }
+  }
+
+  & > .ao-form-control[disabled="disabled"] + .ao-input__addon:hover {
+    color: $color-gray-40;
+    cursor: not-allowed;
+  }
+}
+
+</style>

--- a/src/components/AoDatePicker/AoDatePickerCalendar.vue
+++ b/src/components/AoDatePicker/AoDatePickerCalendar.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="ao-datepickercalendar">
+    <AoDatePickerCalendarDay
+      :input-date="inputDate"
+      :month-names="monthNames"
+      :day-names="dayNames"
+      @selected="emitSelected"
+    />
+    <div class="ao-datepickercalendar__footer">
+      <span
+        class="ao-datepickercalendar__today-button"
+        @click="selectToday"
+      >
+        Today
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+import AoDatePickerCalendarDay from './AoDatePickerCalendarDay'
+import { format, startOfToday } from 'date-fns'
+
+export default {
+  components: {
+    AoDatePickerCalendarDay
+  },
+
+  props: {
+    inputDate: {
+      validator: prop => typeof prop === 'string' || prop === null,
+      required: true
+    },
+
+    monthNames: {
+      type: Array,
+      required: true
+    },
+
+    dayNames: {
+      type: Array,
+      required: true
+    }
+  },
+
+  methods: {
+    emitSelected (date) {
+      this.$emit('selected', format(date, 'YYYY-MM-DD'))
+    },
+
+    selectToday () {
+      this.emitSelected(startOfToday())
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+
+.ao-datepickercalendar {
+  background: $color-white;
+  position: absolute;
+  right: 0;
+  box-shadow: $shadow;
+  z-index: $zindex-dropdown;
+
+  &__footer {
+    padding: .5rem;
+    border-top: 1px solid $ui-border-color-base;
+  }
+
+  &__today-button {
+    color: $font-color-link;
+    font-weight: $font-weight-bold;
+    display: block;
+    width: 100%;
+    text-align: center;
+
+    &:hover {
+      cursor: pointer;
+      color: $font-color-link-hover;
+    }
+  }
+}
+</style>

--- a/src/components/AoDatePicker/AoDatePickerCalendarDay.vue
+++ b/src/components/AoDatePicker/AoDatePickerCalendarDay.vue
@@ -1,0 +1,233 @@
+<template>
+  <div class="ao-datepickercalendarday">
+    <div
+      class="ao-datepickercalendarday__header"
+    >
+      <span
+        class="ao-datepickercalendarday__header-action"
+        @click="showPreviousMonth"
+      >
+        <i class="md-icon__left-chevron" />
+      </span>
+      <span class="ao-datepickercalendarday__header-text">
+        {{ monthName }}
+        {{ year }}
+      </span>
+      <span
+        class="ao-datepickercalendarday__header-action"
+        @click="showNextMonth"
+      >
+        <i class="md-icon__right-chevron" />
+      </span>
+    </div>
+    <div class="ao-datepickercalendarday__content">
+      <div
+        v-for="day in dayNames"
+        :key="day"
+        class="ao-datepickercalendarday__content-header"
+      >
+        {{ day }}
+      </div>
+      <div
+        v-for="dateItem in dates"
+        :key="dateItem.key"
+        :class="classes(dateItem)"
+        @click="emitSelected(dateItem.value)"
+      >
+        {{ dateItem.date }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { getCalendarDatesForMonth, isValidDate } from '../utils/component_utilities.js'
+import { startOfToday, addMonths, subMonths, parse, getMonth, getYear, format } from 'date-fns'
+
+export default {
+  props: {
+    inputDate: {
+      validator: prop => typeof prop === 'string' || prop === null,
+      required: true
+    },
+
+    monthNames: {
+      type: Array,
+      required: true
+    },
+
+    dayNames: {
+      type: Array,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+      calendarDate: startOfToday(),
+      isMonthViewMode: false
+    }
+  },
+
+  computed: {
+    year () {
+      return getYear(this.calendarDate)
+    },
+
+    month () {
+      return getMonth(this.calendarDate)
+    },
+
+    monthName () {
+      return this.monthNames[getMonth(this.calendarDate)]
+    },
+
+    dates () {
+      return getCalendarDatesForMonth(this.calendarDate, this.inputDate)
+    }
+  },
+  watch: {
+    // watch to sync with user typed date
+    inputDate: {
+      handler (newValue) {
+        if (isValidDate(newValue)) {
+          this.calendarDate = parse(newValue)
+        } else {
+          this.calendarDate = startOfToday()
+        }
+      },
+      immediate: true
+    }
+  },
+  methods: {
+    emitSelected (date) {
+      this.$emit('selected', format(date, 'YYYY-MM-DD'))
+    },
+
+    showNextMonth () {
+      this.calendarDate = addMonths(this.calendarDate, 1)
+    },
+
+    showPreviousMonth () {
+      this.calendarDate = subMonths(this.calendarDate, 1)
+    },
+
+    classes (dateItem) {
+      return [
+        'ao-datepickercalendarday__date',
+        {
+          'ao-datepickercalendarday__date--outside': dateItem.month !== this.month,
+          'ao-datepickercalendarday__date--today': dateItem.today,
+          'ao-datepickercalendarday__date--selected': dateItem.selected
+        }
+      ]
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+$datepicker-width: 17.625rem;
+$date-cell-width: ($datepicker-width - 1rem)/7;
+$datepicker-arrow-button-width: 1.625rem;
+
+.ao-datepickercalendarday {
+  width: $datepicker-width;
+
+  &__header {
+    padding: 0.25rem;
+    font-weight: $font-weight-bold;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid $ui-border-color-base;
+  }
+
+  &__header-action {
+    cursor: pointer;
+    padding: .25rem;
+    line-height: 1;
+    border-radius: $border-radius-base;
+    width: $datepicker-arrow-button-width;
+    height: $datepicker-arrow-button-width;
+
+    &:hover {
+      background: $color-gray-80;
+    }
+
+    &:first-child {
+      margin-left: ($date-cell-width - $datepicker-arrow-button-width) - .25rem;
+    }
+    &:last-child {
+      margin-right: ($date-cell-width - $datepicker-arrow-button-width) - .25rem;
+    }
+  }
+
+  &__content {
+    padding: .5rem;
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    text-align: center;
+
+  }
+
+  &__content-header {
+    margin-bottom: 0.2rem;
+    text-transform: uppercase;
+    font-weight: $font-weight-bold;
+    color: $color-gray-40;
+    font-size: .75rem;
+  }
+
+  &__date {
+    cursor: pointer;
+    height: $date-cell-width;
+    width: $date-cell-width;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10rem;
+    font-size: 0.875rem;
+
+    &:hover {
+      background: $color-gray-80;
+    }
+
+    &--outside {
+      color: $color-gray-40;
+    }
+
+    &--today {
+      font-weight: $font-weight-bold;
+      color: $color-dark;
+      position: relative;
+
+      &:after {
+        display: inline-block;
+        content: "";
+        border-radius: 100%;
+        height: 4px;
+        width: 4px;
+        background: $color-dark;
+        position: absolute;
+        bottom: .2rem;
+      }
+    }
+
+    &--selected {
+      background: $color-primary;
+      color: $color-white;
+      font-weight: $font-weight-bold;
+
+      &:hover {
+        background: $color-primary;
+      }
+
+      &:after {
+        background-color: $color-white;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -24,8 +24,9 @@
       >
       <span
         v-if="hasIconAddon"
-        :class="iconClass"
+        :class="[iconClass, { 'ao-input__icon--clickable': hasIconClickableClass }]"
         class="ao-input__addon"
+        @click="emitIconClicked"
         v-html="iconHtml"
       />
       <span
@@ -35,6 +36,7 @@
         {{ addOn }}
       </span>
     </div>
+    <slot name="below-input" />
     <span
       v-show="invalidMessage && invalid"
       class="ao-form-group__invalid-message"
@@ -95,6 +97,11 @@ export default {
       default: null
     },
 
+    isIconClickable: {
+      type: Boolean,
+      default: false
+    },
+
     addOn: {
       type: String,
       default: null
@@ -151,6 +158,10 @@ export default {
       return this.instructionText || (this.invalidMessage && this.invalid)
     },
 
+    hasIconClickableClass () {
+      return this.isIconClickable && !(this.disabled || this.disableAll)
+    },
+
     computedSize () {
       const activeClasses = {
         'ao-form-control--small': this.size === 'small'
@@ -174,6 +185,10 @@ export default {
 
     emitChange (event) {
       this.$emit('change', event.target.value)
+    },
+
+    emitIconClicked (event) {
+      this.hasIconClickableClass && this.$emit('icon-clicked')
     }
   }
 }
@@ -183,4 +198,8 @@ export default {
 
 @import '../assets/styles/mixins/shared-input-styles.scss';
 @include shared-input-styles;
+
+.ao-input__icon--clickable {
+  cursor: pointer;
+}
 </style>

--- a/src/components/utils/component_utilities.js
+++ b/src/components/utils/component_utilities.js
@@ -1,3 +1,41 @@
+import { startOfMonth, addDays, getDate, getDay, isSunday, subDays, getMonth, isToday, isEqual, format } from 'date-fns'
+const dateRegex = /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/
+
 export function filterClasses (classes) {
   return Object.keys(classes).filter(className => classes[className])
+}
+
+export function isValidDate (value) {
+  return dateRegex.test(value)
+}
+
+export function getCalendarDatesForMonth (dateValue, inputDate) {
+  const dates = []
+
+  if (dateValue) {
+    let startDate = startOfMonth(dateValue)
+    if (!isSunday(startDate)) {
+      startDate = subDays(startDate, getDay(startDate))
+    }
+
+    // 42 days = 6 weeks
+    for (let index = 0; index < 42; index += 1) {
+      const calendarDate = addDays(startDate, index)
+      const day = getDay(calendarDate)
+      const date = getDate(calendarDate)
+      const month = getMonth(calendarDate)
+
+      dates.push({
+        key: `${date}-${month}`,
+        day,
+        date,
+        month,
+        today: isToday(calendarDate),
+        selected: isEqual(calendarDate, inputDate),
+        value: format(calendarDate, 'YYYY-MM-DD')
+      })
+    }
+  }
+
+  return dates
 }

--- a/src/router.js
+++ b/src/router.js
@@ -14,6 +14,7 @@ import FileUpload from '../docs/components/FileUpload.vue'
 import HeaderToolbar from '../docs/components/HeaderToolbar.vue'
 import InfoPair from '../docs/components/InfoPair.vue'
 import Input from '../docs/components/Input.vue'
+import DatePicker from '../docs/components/DatePicker.vue'
 import Navbar from '../docs/components/Navbar.vue'
 import Modal from '../docs/components/Modal.vue'
 import Paginate from '../docs/components/Paginate.vue'
@@ -49,6 +50,7 @@ export default new Router({
     { name: 'callout', path: '/callout', component: Callout, meta: { title: 'Callout' } },
     { name: 'card', path: '/card', component: Card, meta: { title: 'Card' } },
     { name: 'checkbox', path: '/checkbox', component: Checkbox, meta: { title: 'Checkbox' } },
+    { name: 'datepicker', path: '/datepicker', component: DatePicker, meta: { title: 'Date Picker' } },
     { name: 'dropdown', path: '/dropdown', component: Dropdown, meta: { title: 'Dropdown' } },
     { name: 'fileupload', path: '/fileupload', component: FileUpload, meta: { title: 'File Upload' } },
     { name: 'headertoolbar', path: '/headertoolbar', component: HeaderToolbar, meta: { title: 'Header Toolbar' } },

--- a/src/views/Demo.vue
+++ b/src/views/Demo.vue
@@ -438,6 +438,19 @@
             :label="radio.value"
           />
 
+          <ao-date-picker
+            v-model="date1"
+            label="Date One"
+          />
+
+          <ao-date-picker
+            v-model="date2"
+            label="Date Two"
+          />
+
+          <p>Date One is: {{ date1 }} </p>
+          <p>Date Two is: {{ date2 }} </p>
+
           <p>When I'm at my desk I prefer to {{ selectedRadio }}</p>
 
           <ao-select
@@ -656,6 +669,8 @@ export default {
       likeBooks: false,
       nicePets: null,
       file: '',
+      date1: null,
+      date2: null,
       pets: [
         { name: 'Dog', value: 'dog' },
         { name: 'Cat', value: 'cat' },

--- a/tests/unit/AoDatePicker/AoDatePicker.spec.js
+++ b/tests/unit/AoDatePicker/AoDatePicker.spec.js
@@ -1,0 +1,103 @@
+import { mount } from '@vue/test-utils'
+import DatePicker from '@/components/AoDatePicker/AoDatePicker.vue'
+
+describe('DatePicker', () => {
+  it('show and hide calendar', () => {
+    const datePicker = mount(DatePicker, {
+      propsData: {
+        label: '',
+        iconClass: 'some-icon'
+      },
+      stubs: ['AoDatePickerCalendar']
+    })
+
+    expect(datePicker.contains('.ao-datepicker')).toBe(true)
+
+    datePicker.find('.ao-input__icon--clickable').trigger('click')
+    expect(datePicker.contains('.ao-datepicker__calendar')).toBe(true)
+
+    datePicker.find('.ao-input__icon--clickable').trigger('click')
+    expect(datePicker.contains('.ao-datepicker__calendar')).toBe(false)
+  })
+
+  it('select date', () => {
+    const datePicker = mount(DatePicker, {
+      propsData: {
+        label: '',
+        iconClass: 'some-icon',
+        value: '2018-01-01'
+      },
+      stubs: {
+        AoDatePickerCalendar: {
+          template: `<p class="ao-datepickercalendar" @selected="$emit('selected')"></p>`
+        }
+      }
+    })
+
+    datePicker.find('.ao-input__icon--clickable').trigger('click')
+    datePicker.find('.ao-datepickercalendar').trigger('selected')
+    expect(datePicker.contains('.ao-datepicker__calendar')).toBe(false)
+  })
+
+  it('emit blur', () => {
+    const input = mount(DatePicker, {
+      propsData: {
+        type: 'text',
+        label: 'label',
+        value: 'value'
+      },
+      stubs: ['AoDatePickerCalendar']
+    })
+
+    input.find('.ao-form-control').trigger('blur')
+    expect(input.emitted().blur).toBeTruthy()
+  })
+
+  it('emit change', () => {
+    const input = mount(DatePicker, {
+      propsData: {
+        type: 'text',
+        label: 'label',
+        value: 'value'
+      },
+      stubs: ['AoDatePickerCalendar']
+    })
+
+    input.find('.ao-form-control').trigger('change')
+    expect(input.emitted().change[0][0]).toBe('value')
+  })
+
+  it('emit focus', () => {
+    const input = mount(DatePicker, {
+      propsData: {
+        type: 'text',
+        label: 'label',
+        value: 'value'
+      },
+      stubs: ['AoDatePickerCalendar']
+    })
+
+    input.find('.ao-form-control').trigger('focus')
+    expect(input.emitted().focus).toBeTruthy()
+  })
+
+  it('hide calendar when click outside', () => {
+    const input = mount(DatePicker, {
+      propsData: {
+        type: 'text',
+        label: 'label',
+        value: 'value'
+      },
+      stubs: ['AoDatePickerCalendar'],
+      directives: {
+        clickOutside: {
+          bind (el, binding, vnode) {
+            vnode.context[binding.expression]()
+          }
+        }
+      }
+    })
+
+    expect(input.contains('.ao-datepicker__calendar')).toBe(false)
+  })
+})

--- a/tests/unit/AoDatePicker/AoDatePickerCalendar.spec.js
+++ b/tests/unit/AoDatePicker/AoDatePickerCalendar.spec.js
@@ -1,0 +1,19 @@
+import { mount } from '@vue/test-utils'
+import AoDatePickerCalendar from '@/components/AoDatePicker/AoDatePickerCalendar.vue'
+
+describe('AoDatePickerCalendar', () => {
+  it('today', () => {
+    const datePicker = mount(AoDatePickerCalendar, {
+      propsData: {
+        inputDate: '',
+        monthNames: [],
+        dayNames: []
+      },
+      stubs: ['AoDatePickerCalendarDay']
+    })
+
+    datePicker.find('.ao-datepickercalendar__today-button').trigger('click')
+    expect(datePicker.classes()).toContain('ao-datepickercalendar')
+    expect(datePicker.emitted().selected).toBeTruthy()
+  })
+})

--- a/tests/unit/AoDatePicker/AoDatePickerCalendarDay.spec.js
+++ b/tests/unit/AoDatePicker/AoDatePickerCalendarDay.spec.js
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils'
+import AoDatePickerCalendarDay from '@/components/AoDatePicker/AoDatePickerCalendarDay.vue'
+
+describe('AoDatePickerCalendarDay', () => {
+  const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+  it('render', () => {
+    const calendar = mount(AoDatePickerCalendarDay, {
+      propsData: {
+        inputDate: null,
+        monthNames,
+        dayNames
+      }
+    })
+
+    calendar.setProps({ inputDate: '2018-02-01' })
+    expect(calendar.classes()).toContain('ao-datepickercalendarday')
+  })
+
+  it('show next month', () => {
+    const calendar = mount(AoDatePickerCalendarDay, {
+      propsData: {
+        inputDate: '2018-02-01',
+        monthNames,
+        dayNames
+      }
+    })
+
+    calendar.findAll('.ao-datepickercalendarday__header-action').at(1).trigger('click')
+    expect(calendar.find('.ao-datepickercalendarday__date').text()).toContain('25')
+  })
+
+  it('show previous month', () => {
+    const calendar = mount(AoDatePickerCalendarDay, {
+      propsData: {
+        inputDate: '2018-02-01',
+        monthNames,
+        dayNames
+      }
+    })
+
+    calendar.findAll('.ao-datepickercalendarday__header-action').at(0).trigger('click')
+    expect(calendar.find('.ao-datepickercalendarday__date').text()).toContain('31')
+  })
+
+  it('select a date', () => {
+    const calendar = mount(AoDatePickerCalendarDay, {
+      propsData: {
+        inputDate: '2018-02-01',
+        monthNames,
+        dayNames
+      }
+    })
+
+    calendar.findAll('.ao-datepickercalendarday__date').at(15).trigger('click')
+    expect(calendar.emitted().selected).toEqual([['2018-02-12']])
+  })
+})

--- a/tests/unit/AoInput.spec.js
+++ b/tests/unit/AoInput.spec.js
@@ -26,6 +26,18 @@ describe('Input', () => {
     expect(input.contains('.custom-glyph-clients')).toBe(true)
   })
 
+  it('isIconClickable', () => {
+    const input = mount(Input, {
+      propsData: {
+        label: 'label',
+        iconClass: 'some-icon',
+        isIconClickable: true
+      }
+    })
+    input.find('.ao-input__icon--clickable').trigger('click')
+    expect(input.emitted()['icon-clicked']).toBeTruthy()
+  })
+
   it('invalid', () => {
     const input = mount(Input, {
       propsData: {

--- a/tests/unit/directives/clickOutside.spec.js
+++ b/tests/unit/directives/clickOutside.spec.js
@@ -1,0 +1,33 @@
+import clickOutside from '@/directives/click-outside'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+
+describe('directives/clickOutside', () => {
+  it('should be able to bind', async () => {
+    const foo = jest.fn()
+    const localVue = createLocalVue()
+    localVue.directive('clickOutside', clickOutside)
+
+    const wrapper = shallowMount(
+      {
+        template: `<div>
+        <h1 class="header"></h1>
+        <button v-click-outside="foo">button</button>
+      </div>`,
+        methods: {
+          foo
+        }
+      },
+      {
+        localVue,
+        attachToDocument: true
+      }
+    )
+
+    wrapper.find('button').trigger('click')
+
+    wrapper.find('.header').trigger('click')
+    wrapper.destroy()
+
+    expect(foo).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/utils/component_utilities.spec.js
+++ b/tests/unit/utils/component_utilities.spec.js
@@ -1,0 +1,63 @@
+import { isValidDate, getCalendarDatesForMonth } from '@/components/utils/component_utilities'
+
+describe('utils/component_utilities', () => {
+  it('isValidDate', () => {
+    expect(isValidDate('2018-01-01')).toBe(true)
+    expect(isValidDate('20018-01-01')).toBe(false)
+    expect(isValidDate('2008-001-01')).toBe(false)
+    expect(isValidDate('2018-01-001')).toBe(false)
+    expect(isValidDate('2018-1-01')).toBe(false)
+    expect(isValidDate('2018-1-1')).toBe(false)
+  })
+
+  it('getCalendarDatesForMonth', () => {
+    const expectedResult = [
+      { date: 28, day: 0, key: '28-0', month: 0, selected: false, today: false, value: '2018-01-28' },
+      { date: 29, day: 1, key: '29-0', month: 0, selected: false, today: false, value: '2018-01-29' },
+      { date: 30, day: 2, key: '30-0', month: 0, selected: false, today: false, value: '2018-01-30' },
+      { date: 31, day: 3, key: '31-0', month: 0, selected: false, today: false, value: '2018-01-31' },
+      { date: 1, day: 4, key: '1-1', month: 1, selected: true, today: false, value: '2018-02-01' },
+      { date: 2, day: 5, key: '2-1', month: 1, selected: false, today: false, value: '2018-02-02' },
+      { date: 3, day: 6, key: '3-1', month: 1, selected: false, today: false, value: '2018-02-03' },
+      { date: 4, day: 0, key: '4-1', month: 1, selected: false, today: false, value: '2018-02-04' },
+      { date: 5, day: 1, key: '5-1', month: 1, selected: false, today: false, value: '2018-02-05' },
+      { date: 6, day: 2, key: '6-1', month: 1, selected: false, today: false, value: '2018-02-06' },
+      { date: 7, day: 3, key: '7-1', month: 1, selected: false, today: false, value: '2018-02-07' },
+      { date: 8, day: 4, key: '8-1', month: 1, selected: false, today: false, value: '2018-02-08' },
+      { date: 9, day: 5, key: '9-1', month: 1, selected: false, today: false, value: '2018-02-09' },
+      { date: 10, day: 6, key: '10-1', month: 1, selected: false, today: false, value: '2018-02-10' },
+      { date: 11, day: 0, key: '11-1', month: 1, selected: false, today: false, value: '2018-02-11' },
+      { date: 12, day: 1, key: '12-1', month: 1, selected: false, today: false, value: '2018-02-12' },
+      { date: 13, day: 2, key: '13-1', month: 1, selected: false, today: false, value: '2018-02-13' },
+      { date: 14, day: 3, key: '14-1', month: 1, selected: false, today: false, value: '2018-02-14' },
+      { date: 15, day: 4, key: '15-1', month: 1, selected: false, today: false, value: '2018-02-15' },
+      { date: 16, day: 5, key: '16-1', month: 1, selected: false, today: false, value: '2018-02-16' },
+      { date: 17, day: 6, key: '17-1', month: 1, selected: false, today: false, value: '2018-02-17' },
+      { date: 18, day: 0, key: '18-1', month: 1, selected: false, today: false, value: '2018-02-18' },
+      { date: 19, day: 1, key: '19-1', month: 1, selected: false, today: false, value: '2018-02-19' },
+      { date: 20, day: 2, key: '20-1', month: 1, selected: false, today: false, value: '2018-02-20' },
+      { date: 21, day: 3, key: '21-1', month: 1, selected: false, today: false, value: '2018-02-21' },
+      { date: 22, day: 4, key: '22-1', month: 1, selected: false, today: false, value: '2018-02-22' },
+      { date: 23, day: 5, key: '23-1', month: 1, selected: false, today: false, value: '2018-02-23' },
+      { date: 24, day: 6, key: '24-1', month: 1, selected: false, today: false, value: '2018-02-24' },
+      { date: 25, day: 0, key: '25-1', month: 1, selected: false, today: false, value: '2018-02-25' },
+      { date: 26, day: 1, key: '26-1', month: 1, selected: false, today: false, value: '2018-02-26' },
+      { date: 27, day: 2, key: '27-1', month: 1, selected: false, today: false, value: '2018-02-27' },
+      { date: 28, day: 3, key: '28-1', month: 1, selected: false, today: false, value: '2018-02-28' },
+      { date: 1, day: 4, key: '1-2', month: 2, selected: false, today: false, value: '2018-03-01' },
+      { date: 2, day: 5, key: '2-2', month: 2, selected: false, today: false, value: '2018-03-02' },
+      { date: 3, day: 6, key: '3-2', month: 2, selected: false, today: false, value: '2018-03-03' },
+      { date: 4, day: 0, key: '4-2', month: 2, selected: false, today: false, value: '2018-03-04' },
+      { date: 5, day: 1, key: '5-2', month: 2, selected: false, today: false, value: '2018-03-05' },
+      { date: 6, day: 2, key: '6-2', month: 2, selected: false, today: false, value: '2018-03-06' },
+      { date: 7, day: 3, key: '7-2', month: 2, selected: false, today: false, value: '2018-03-07' },
+      { date: 8, day: 4, key: '8-2', month: 2, selected: false, today: false, value: '2018-03-08' },
+      { date: 9, day: 5, key: '9-2', month: 2, selected: false, today: false, value: '2018-03-09' },
+      { date: 10, day: 6, key: '10-2', month: 2, selected: false, today: false, value: '2018-03-10' }
+    ]
+
+    expect(getCalendarDatesForMonth('2018-02-28', '2018-02-01')).toEqual(expectedResult)
+    expect(getCalendarDatesForMonth('2018-04-01', '')).toBeTruthy()
+    expect(getCalendarDatesForMonth(null, null)).toEqual([])
+  })
+})


### PR DESCRIPTION
# Link to Github Issue
https://github.com/AmpleOrganics/Blaze.vue/issues/312

# Description
AoDatePicker component that allows users to type date or use pick date picker to select a date

# Scope and QA
Following functionality is complete: 
- Date format is: YYYY-MM-DD (2018-01-01)
- User can type in date
- Typed date is synced with date picker
- User can click on icon to toggle date picker
- User can navigate months in date picker using arrows on top left and right
- Styling for selected date and today's date

- [x] Functionality
- [x] Styling
- [x] Unit Tests  

![AoDatePicker](https://user-images.githubusercontent.com/9040052/54826796-f9b18480-4c86-11e9-804a-4b55d97bca55.gif)
