### PR TITLE
Button: Align material icons vertically with text

### DIFF
--- a/docs/components/Button.vue
+++ b/docs/components/Button.vue
@@ -19,6 +19,12 @@
           :jumbo="activateProp('jumbo')"
           :disabled="disabled"
         >
+          <i
+            v-if="materialIcon"
+            class="material-icons"
+          >
+            get_app
+          </i>
           {{ buttonText }}
         </ao-button>
       </div>
@@ -74,6 +80,11 @@
         </div>
         <div class="component-controls__group">
           <ao-checkbox
+            v-model="materialIcon"
+            :checkbox-value="true"
+            checkbox-label="Material Icon"
+          />
+          <ao-checkbox
             v-model="disabled"
             :checkbox-value="true"
             checkbox-label="disabled"
@@ -127,7 +138,8 @@ export default {
         { name: 'Text Only & Link', value: 'text-only-link' }
       ],
       selectedStyle: 'default',
-      disabled: false
+      disabled: false,
+      materialIcon: false
     }
   },
 

--- a/src/components/AoButton.vue
+++ b/src/components/AoButton.vue
@@ -127,7 +127,9 @@ export default {
 }
 
 .ao-button {
- display: inline-block;
+ display: inline-flex;
+ align-items: center;
+ justify-content: center;
  margin-bottom: 0;
  text-align: center;
  font-weight: $font-weight-bold;


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/320

# Description

Material icons were aligned with the top of the button, should instead be aligned vertically in the middle to match up with the text.
Also updated the button page in the docs to demo the icon.