### PR TITLE
Select & TextArea: Name prop inclusion

### DIFF
--- a/docs/components/Select.js
+++ b/docs/components/Select.js
@@ -27,6 +27,7 @@ data () {
   apiRows: [
     { name: 'value', type: 'String, Number, Boolean', default: 'null', description: 'This prop defines the selected value.' },
     { name: 'label', type: 'String, required', default: 'null', description: 'This prop defines the label of the select.' },
+    { name: 'name', type: 'String', default: 'null', description: 'This prop defines the name of the select.' },
     { name: 'showLabel', type: 'Boolean', default: 'true', description: 'This prop defines if the select label will be shown or not.' },
     { name: 'instructionText', type: 'String', default: 'null', description: 'Instruction text to show below the input.' },
     { name: 'invalid', type: 'Boolean', default: 'false', description: 'This prop defines the select to be invalid.' },

--- a/src/components/AoSelect.vue
+++ b/src/components/AoSelect.vue
@@ -14,6 +14,7 @@
         :value="selected"
         :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control', computedSize]"
         :disabled="disabled || disableAll"
+        :name="name"
         @change="emitChange"
         @blur="emitBlur"
         @focus="emitFocus"
@@ -62,6 +63,11 @@ export default {
     showLabel: {
       type: Boolean,
       default: true
+    },
+
+    name: {
+      type: String,
+      default: null
     },
 
     invalid: {

--- a/src/components/AoTextArea.vue
+++ b/src/components/AoTextArea.vue
@@ -14,6 +14,7 @@
       :class="{'ao-form-control--invalid': invalid }"
       :value="value"
       :disabled="disabled || disableAll"
+      :name="name"
       class="ao-form-control"
       @input="emitInput"
       @blur="emitBlur"
@@ -45,6 +46,11 @@ export default {
     },
 
     label: {
+      type: String,
+      default: null
+    },
+
+    name: {
       type: String,
       default: null
     },


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/309

# Description

Name prop was being used but was not defined in props for components