### PR TITLE
Docs: Adjust code snippet spacing formatting

### DIFF
--- a/docs/components/Alert.js
+++ b/docs/components/Alert.js
@@ -5,7 +5,8 @@ export default {
         `<ao-alert
   v-if="showAlert"
   :show-alert="true"
-  :icon-class="'md-icon__check'">
+  :icon-class="'md-icon__check'"
+>
   <i
     slot="icon"
     class="material-icons"

--- a/docs/components/Alert.vue
+++ b/docs/components/Alert.vue
@@ -51,7 +51,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Badge.vue
+++ b/docs/components/Badge.vue
@@ -38,7 +38,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Breadcrumbs.vue
+++ b/docs/components/Breadcrumbs.vue
@@ -10,7 +10,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Button.vue
+++ b/docs/components/Button.vue
@@ -93,7 +93,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Callout.js
+++ b/docs/components/Callout.js
@@ -3,13 +3,14 @@ export default {
   description: 'This is a customizable callout component.',
   snippet:
         `<ao-callout
-      v-if="showCallout"
-      success
-      dismissible
-      :icon-class="'md-icon__check'"
-      @hideCallout="hideCallout">
-      Callout text goes here
-    </ao-callout>`,
+  v-if="showCallout"
+  success
+  dismissible
+  :icon-class="'md-icon__check'"
+  @hideCallout="hideCallout"
+>
+  Callout text goes here
+</ao-callout>`,
   apiRows: [
     { name: 'iconClass', type: 'String', default: 'null', description: 'Displays icon components eg. material icons.' },
     { name: 'dismissible', type: 'Boolean', default: 'false', description: 'Displays a close icon on right side of callout' },

--- a/docs/components/Callout.vue
+++ b/docs/components/Callout.vue
@@ -74,7 +74,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Card.vue
+++ b/docs/components/Card.vue
@@ -34,7 +34,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Checkbox.vue
+++ b/docs/components/Checkbox.vue
@@ -38,7 +38,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/DatePicker.vue
+++ b/docs/components/DatePicker.vue
@@ -106,7 +106,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Dropdown.js
+++ b/docs/components/Dropdown.js
@@ -8,21 +8,21 @@ export default {
     v-for="(link, index) in links"
     class="ao-dropdown__link"
     :key="index"
-    :href="link.url">
+    :href="link.url"
+  >
     {{ link.title }}
   </ao-dropdown-item>
 </ao-dropdown>
 
-    data () {
-      return {
-        links: [
-          { url: "https://google.com", title: "Google" },
-          { url: "https://facebook.com", title: "Facebook" }
-        ],
-
-        showDropdown: true
-      }
-    }`,
+data () {
+  return {
+    links: [
+      { url: "https://google.com", title: "Google" },
+      { url: "https://facebook.com", title: "Facebook" }
+    ],
+    showDropdown: true
+  }
+}`,
   apiRows: [
     { name: 'showDropdown', type: 'Boolean', default: 'false', description: 'Hides or un-hides the dropdown.' }
   ]

--- a/docs/components/Dropdown.vue
+++ b/docs/components/Dropdown.vue
@@ -28,7 +28,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/DropdownItem.vue
+++ b/docs/components/DropdownItem.vue
@@ -21,7 +21,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/FileUpload.vue
+++ b/docs/components/FileUpload.vue
@@ -56,7 +56,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/HeaderToolbar.js
+++ b/docs/components/HeaderToolbar.js
@@ -5,7 +5,8 @@ export default {
     `<ao-header-toolbar
   :title="'Ribbitting Technologies'"
   :icon-html="'🐸'"
-  fixed>
+  fixed
+>
   <span>🍔</span>
   <span>Logout</span>
 </ao-header-toolbar>`,

--- a/docs/components/HeaderToolbar.vue
+++ b/docs/components/HeaderToolbar.vue
@@ -54,7 +54,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/InfoPair.vue
+++ b/docs/components/InfoPair.vue
@@ -30,7 +30,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Input.vue
+++ b/docs/components/Input.vue
@@ -170,7 +170,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Modal.js
+++ b/docs/components/Modal.js
@@ -5,14 +5,16 @@ export default {
         `<ao-modal
   v-if="showModal"
   :header-text="'This is the modal title'"
-  @modalClose="toggleModal">
+  @modalClose="toggleModal"
+>
   <div slot="modal-body">
     <p>And I live in the body of the modal</p>
   </div>
   <div slot="modal-footer">
     <ao-button
       primary
-      @click.native="toggleModal">
+      @click.native="toggleModal"
+    >
       Close
     </ao-button>
   </div>

--- a/docs/components/Modal.vue
+++ b/docs/components/Modal.vue
@@ -74,7 +74,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Navbar.js
+++ b/docs/components/Navbar.js
@@ -5,7 +5,8 @@ export default {
         `<ao-navbar>
   <li
     v-for="route in routes"
-    :key="route.path">
+    :key="route.path"
+  >
     <router-link :to="route.path" >{{ route.name }}</router-link>
   </li>
 </ao-navbar>

--- a/docs/components/Navbar.vue
+++ b/docs/components/Navbar.vue
@@ -19,7 +19,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Paginate.js
+++ b/docs/components/Paginate.js
@@ -2,8 +2,7 @@ export default {
   header: 'Paginate',
   description: 'This is a pagination component allowing you to navigate between pages.',
   snippet:
-  `
-<ao-paginate
+  `<ao-paginate
   :total-pages="3"
   :current-page.sync="currentPage"
 />

--- a/docs/components/Paginate.vue
+++ b/docs/components/Paginate.vue
@@ -24,7 +24,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Radio.vue
+++ b/docs/components/Radio.vue
@@ -20,7 +20,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/RadioButtonGroup.js
+++ b/docs/components/RadioButtonGroup.js
@@ -3,23 +3,23 @@ export default {
   description: 'A group of radio inputs styled as buttons',
   snippet:
         `<ao-radio-button-group
-    :options="radioOptions"
-    :name="'radio'"
-    v-model="selectedRadio"
-  />
+  :options="radioOptions"
+  :name="'radio'"
+  v-model="selectedRadio"
+/>
 
-  data () {
-    return {
-      radioOptions: [
-        { name: 'Tandy', value: 'Tandy' },
-        { name: 'Carol', value: 'Carol' },
-        { name: 'Gail', value: 'Gail' },
-        { name: 'Erica', value: 'Erica' },
-        { name: 'Todd', value: 'Todd' }
-      ],
-      selectedRadio: null
-    }
-  }`,
+data () {
+  return {
+    radioOptions: [
+      { name: 'Tandy', value: 'Tandy' },
+      { name: 'Carol', value: 'Carol' },
+      { name: 'Gail', value: 'Gail' },
+      { name: 'Erica', value: 'Erica' },
+      { name: 'Todd', value: 'Todd' }
+    ],
+    selectedRadio: ''
+  }
+}`,
   apiRows: [
     { name: 'options', type: 'Array, required', description: 'this props provides radio options for the radio buttons, check the example for how they should be structured' },
     { name: 'name', type: 'String, required', description: 'this prop links each radio button together' }

--- a/docs/components/RadioButtonGroup.vue
+++ b/docs/components/RadioButtonGroup.vue
@@ -17,7 +17,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
@@ -44,7 +44,7 @@ export default {
         { name: 'Other Guy', value: 'Other' },
         { name: 'Todd', value: 'Todd' }
       ],
-      selectedRadio: null
+      selectedRadio: ''
     }
   }
 }

--- a/docs/components/SectionHeader.vue
+++ b/docs/components/SectionHeader.vue
@@ -43,7 +43,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Select.js
+++ b/docs/components/Select.js
@@ -5,10 +5,12 @@ export default {
         `<ao-select
   v-model="selected"
   :label="'Label'"
-  :placeholder="'Placeholder'">
+  :placeholder="'Placeholder'"
+>
   <option
     v-for="option in options"
-    :value="option.value">
+    :value="option.value"
+  >
     {{option.name}}
   </option>
 </ao-select>

--- a/docs/components/Select.vue
+++ b/docs/components/Select.vue
@@ -81,7 +81,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Spinner.vue
+++ b/docs/components/Spinner.vue
@@ -10,7 +10,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Table.js
+++ b/docs/components/Table.js
@@ -2,8 +2,7 @@ export default {
   header: 'Table',
   description: 'This is a customizable table component.',
   snippet:
-`
-<ao-table
+`<ao-table
   :headers="headers"
   :is-clickable="isClickable"
   :show-no-data-text="showNoDataText"
@@ -11,10 +10,12 @@ export default {
   :sort-by="sortBy"
   :order="order"
   class="component-example-table"
-  @sortTable="sortTable">
+  @sortTable="sortTable"
+>
   <tr
     v-for="user in filteredUsers"
-    :key="user.id">
+    :key="user.id"
+  >
     <td>{{ user.id }}</td>
     <td>{{ user.first_name }}</td>
     <td>{{ user.last_name }}</td>

--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -73,7 +73,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/TableCell.js
+++ b/docs/components/TableCell.js
@@ -2,8 +2,7 @@ export default {
   header: 'Table Cell',
   description: 'This styles and sizes inputs and buttons consistently.',
   snippet:
-`
-<ao-table-cell content="button" >
+`<ao-table-cell content="button" >
   <ao-tooltip text="Archive">
     <ao-button>
       <i class="md-icon__archive" />
@@ -19,8 +18,7 @@ export default {
       <i class="md-icon__more_horiz" />
     </ao-button>
   </ao-tooltip>
-</ao-table-cell>
-    `,
+</ao-table-cell>`,
   apiRows: [
     { name: 'content', type: 'String', default: 'null', description: 'This prop will style either a button or an input appropriately.' },
     { name: 'alignRight', type: 'Boolean', default: 'false', description: 'This prop will align the text in the table cell to the right.' }

--- a/docs/components/TableCell.vue
+++ b/docs/components/TableCell.vue
@@ -60,7 +60,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/TextArea.vue
+++ b/docs/components/TextArea.vue
@@ -85,7 +85,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/TextStyle.js
+++ b/docs/components/TextStyle.js
@@ -4,7 +4,8 @@ export default {
   snippet:
         `<ao-text-style
   error
-  small>
+  small
+>
   This is some sample text
 </ao-text-style>`,
   apiRows: [

--- a/docs/components/TextStyle.vue
+++ b/docs/components/TextStyle.vue
@@ -55,7 +55,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />

--- a/docs/components/Tooltip.js
+++ b/docs/components/Tooltip.js
@@ -5,7 +5,8 @@ export default {
         `<ao-tooltip
   position="bottom"
   text="Tooltip text goes here"
-  multiline>
+  multiline
+>
   <ao-button primary>Hover over me</ao-button>
 </ao-tooltip>`,
   apiRows: [

--- a/docs/components/Tooltip.vue
+++ b/docs/components/Tooltip.vue
@@ -48,7 +48,7 @@
       </div>
     </div>
     <template slot="snippet">
-      {{ snippet }}
+      <code>{{ snippet }}</code>
     </template>
     <template slot="api">
       <ApiTable :rows="apiRows" />


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/259

# Description

The code snippet spacing should no longer have spacing above and below the text content and the starting line should be left aligned.

Essentially this
```
<template slot="snippet">
      {{ snippet }}
</template>
```
causes the new line after the opening tag and the space before the snippet expression to place spacing before the text content.

So I put `<code>{{ snippet }}</code>` instead to go around that.

