### PR TITLE
AoInfoPair: add support for html label

### DIFF
--- a/docs/components/InfoPair.js
+++ b/docs/components/InfoPair.js
@@ -2,10 +2,14 @@ export default {
   header: 'Info Pair',
   description: 'This is a customizable info pair component.',
   snippet:
-        `<ao-info-pair :label="label">
+`<ao-info-pair
+  :label="label"
+  :label-html="labelHtml"
+>
   {{ info }}
 </ao-info-pair>`,
   apiRows: [
-    { name: 'label', type: 'String, required', default: '-', description: 'Label for info pair.' }
+    { name: 'label', type: 'String', default: '-', description: 'Label for info pair.' },
+    { name: 'label-html', type: 'String', default: '-', description: 'HTML label for info pair.' }
   ]
 }

--- a/docs/components/InfoPair.vue
+++ b/docs/components/InfoPair.vue
@@ -6,7 +6,10 @@
 
     <div slot="example">
       <div class="component-example">
-        <ao-info-pair :label="label">
+        <ao-info-pair
+          :label="label"
+          :label-html="labelHtml"
+        >
           {{ info }}
         </ao-info-pair>
       </div>
@@ -16,6 +19,15 @@
             v-model="label"
             :type="'text'"
             :label="'Info Pair Label Text'"
+          />
+        </div>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="labelHtml"
+            :type="'text'"
+            :label="'Info Pair Label HTML'"
           />
         </div>
       </div>
@@ -52,8 +64,16 @@ export default {
     return {
       ...InfoPairDocumentation,
       label: 'Info Label',
+      labelHtml: '- Area (m<sup>2</sup>)',
       info: 'Information goes here'
     }
   }
 }
 </script>
+
+<style lang="scss" scoped>
+/deep/ sup {
+  font-size: 10px;
+  vertical-align: super;
+}
+</style>

--- a/src/components/AoInfoPair.vue
+++ b/src/components/AoInfoPair.vue
@@ -2,7 +2,13 @@
   <div class="ao-info-pair">
     <div class="ao-info-pair__label">
       <h4 class="ao-info-pair__label-text">
-        {{ label }}
+        <span v-if="label">
+          {{ label }}
+        </span>
+        <span
+          v-if="labelHtml"
+          v-html="labelHtml"
+        />
       </h4>
       <slot name="tooltip" />
     </div>
@@ -17,7 +23,11 @@ export default {
   props: {
     label: {
       type: String,
-      required: true
+      default: ''
+    },
+    labelHtml: {
+      type: String,
+      default: ''
     }
   }
 }


### PR DESCRIPTION
# Link to Github Issue
https://github.com/AmpleOrganics/Blaze.vue/issues/326

# Description
Add support for html label

# QA
* Launch app from console
* Navigate to `Info Pair` component
![image](https://user-images.githubusercontent.com/9040052/57032037-4fc6ff80-6c17-11e9-9111-0f25e7c4e9b1.png)
