### PR TITLE
fix spacing issue in code snippet rendering in docs

### DIFF
--- a/docs/components/.eslintrc.js
+++ b/docs/components/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'vue/singleline-html-element-content-newline': 'off'
+  }
+}

--- a/docs/components/Alert.vue
+++ b/docs/components/Alert.vue
@@ -50,9 +50,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Badge.vue
+++ b/docs/components/Badge.vue
@@ -37,9 +37,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Breadcrumbs.vue
+++ b/docs/components/Breadcrumbs.vue
@@ -9,9 +9,7 @@
         <ao-breadcrumbs :paths="paths" />
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Button.vue
+++ b/docs/components/Button.vue
@@ -92,9 +92,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Callout.vue
+++ b/docs/components/Callout.vue
@@ -73,9 +73,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Card.vue
+++ b/docs/components/Card.vue
@@ -33,9 +33,7 @@
         />
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Checkbox.vue
+++ b/docs/components/Checkbox.vue
@@ -37,9 +37,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/DatePicker.vue
+++ b/docs/components/DatePicker.vue
@@ -105,9 +105,7 @@
         />
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Dropdown.vue
+++ b/docs/components/Dropdown.vue
@@ -27,9 +27,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/DropdownItem.vue
+++ b/docs/components/DropdownItem.vue
@@ -20,9 +20,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/FileUpload.vue
+++ b/docs/components/FileUpload.vue
@@ -55,9 +55,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/HeaderToolbar.vue
+++ b/docs/components/HeaderToolbar.vue
@@ -53,9 +53,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/InfoPair.vue
+++ b/docs/components/InfoPair.vue
@@ -29,9 +29,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Input.vue
+++ b/docs/components/Input.vue
@@ -169,9 +169,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Modal.vue
+++ b/docs/components/Modal.vue
@@ -73,9 +73,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Navbar.vue
+++ b/docs/components/Navbar.vue
@@ -18,9 +18,7 @@
         </ao-navbar>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Paginate.vue
+++ b/docs/components/Paginate.vue
@@ -23,9 +23,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Radio.vue
+++ b/docs/components/Radio.vue
@@ -19,9 +19,7 @@
         />
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/RadioButtonGroup.vue
+++ b/docs/components/RadioButtonGroup.vue
@@ -16,9 +16,7 @@
         />
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/SectionHeader.vue
+++ b/docs/components/SectionHeader.vue
@@ -42,9 +42,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Select.vue
+++ b/docs/components/Select.vue
@@ -80,9 +80,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Spinner.vue
+++ b/docs/components/Spinner.vue
@@ -9,9 +9,7 @@
         <ao-spinner />
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -72,9 +72,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/TableCell.vue
+++ b/docs/components/TableCell.vue
@@ -59,9 +59,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/TextArea.vue
+++ b/docs/components/TextArea.vue
@@ -84,9 +84,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/TextStyle.vue
+++ b/docs/components/TextStyle.vue
@@ -54,9 +54,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>

--- a/docs/components/Tooltip.vue
+++ b/docs/components/Tooltip.vue
@@ -47,9 +47,7 @@
         </div>
       </div>
     </div>
-    <template slot="snippet">
-      {{ snippet }}
-    </template>
+    <template slot="snippet">{{ snippet }}</template>
     <template slot="api">
       <ApiTable :rows="apiRows" />
     </template>


### PR DESCRIPTION
# Link to Github Issue
https://github.com/AmpleOrganics/Blaze.vue/issues/328

# Description
Content of `pre` tag is rendered as it is. New Line eslint rule forces to have a new line that messes up the `Code Snippet` content.

![image](https://user-images.githubusercontent.com/9040052/57231758-2d532e80-6fe9-11e9-8318-7c1bbd0e9416.png)

1. Disable New Line rule in `docs`
2. Update snippet tag to have no new lines and spaces