### PR TITLE
Create a maxHeight property for scrollable tables

### DIFF
--- a/docs/components/Table.js
+++ b/docs/components/Table.js
@@ -6,6 +6,7 @@ export default {
   :headers="headers"
   :is-clickable="isClickable"
   :is-scrollable="isScrollable"
+  :max-height="maxHeight"
   :show-no-data-text="showNoDataText"
   :no-data-text="noDataText"
   :sort-by="sortBy"
@@ -58,7 +59,8 @@ data () {
     isScrollable: false,
     showNoDataText: false,
     noDataText: 'No Data',
-    selectableTable: false
+    selectableTable: false,
+    maxHeight: '200px'
   }
 },
 computed: {
@@ -85,6 +87,7 @@ methods: {
     { name: 'headers > alignRight,<br /> hidden', type: 'Boolean', default: 'false', description: 'Include the <strong>alignRight</strong> property to align the header to the right side of the space given. <br />Include a <strong>hidden</strong> property to hide a given \'th\' header.' },
     { name: 'isClickable', type: 'Boolean', default: 'false', description: 'When set to true, this prop adds appropriate styling to signify that the table and table rows are clickable.' },
     { name: 'isScrollable', type: 'Boolean', default: 'false', description: 'When set to true, this prop adds appropriate styling to make table body scroll on the y-axis if it hits a max-height.' },
+    { name: 'maxHeight', type: 'String', default: '', description: 'Defines the max height of a table in pixels when <strong>isScrollable</strong> is true.' },
     { name: 'noDataText', type: 'String', default: '', description: 'Text to show when table has no data.' },
     { name: 'order', type: 'String ("asc" or "desc")', default: 'desc', description: 'This prop defines which order (ascending or decending) is the default.' },
     { name: 'showNoDataText', type: 'Boolean', default: 'false', description: 'When set to true, this prop displays the value of prop noDataText.' },

--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -10,6 +10,7 @@
           :headers="headers"
           :is-clickable="isClickable"
           :is-scrollable="isScrollable"
+          :max-height="maxHeight"
           :show-no-data-text="showNoDataText"
           :no-data-text="noDataText"
           :sort-by="sortBy"
@@ -110,6 +111,15 @@
           />
         </div>
       </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="maxHeight"
+            :type="'text'"
+            label="maxHeight"
+          />
+        </div>
+      </div>
     </div>
     <template slot="snippet">
       <code>{{ snippet }}</code>
@@ -154,7 +164,8 @@ export default {
       hidden: true,
       showNoDataText: false,
       noDataText: 'No Data',
-      selectableTable: false
+      selectableTable: false,
+      maxHeight: '200px'
     }
   },
 

--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -28,7 +28,10 @@
         </th>
       </tr>
     </thead>
-    <tbody :class=" { clickable: isClickable }">
+    <tbody
+      :class=" { clickable: isClickable }"
+      :style="getMaxHeight(maxHeight)"
+    >
       <slot />
       <tr
         v-if="showNoDataText"
@@ -109,6 +112,11 @@ export default {
     isScrollable: {
       type: Boolean,
       default: false
+    },
+
+    maxHeight: {
+      type: String,
+      default: 'none'
     }
   },
 
@@ -171,6 +179,12 @@ export default {
 
     isSortable (sortable, hidden) {
       return sortable === true && hidden === false
+    },
+
+    getMaxHeight () {
+      return {
+        'max-height': this.maxHeight
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

Styling the **table tbody** element outside of Blaze was proving impossible, this improvement gives the ability to pass in a String value to define the max-height of a table when using the `isScrollable` feature.