### PR TITLE
Add Radio and Checkbox info text prop

### DIFF
--- a/docs/components/Checkbox.js
+++ b/docs/components/Checkbox.js
@@ -6,12 +6,14 @@ export default {
   checkbox-label="Label"
   :show-label="true"
   :checkbox-value="true"
+  info-text="This is some informative text"
 />`,
   apiRows: [
     { name: 'value', type: '[Array, Boolean, Number, Object]', default: 'null', description: 'Defines the value associated with the input (this is also the value that is sent on submit).' },
     { name: 'checkboxValue', type: '[String, Number, Boolean, Object], required', default: 'true', description: 'Defines the value associated with the input.' },
     { name: 'showLabel', type: 'Boolean', default: 'true', description: 'Hide or unhide the text label.' },
     { name: 'checkboxLabel', type: 'String, required', default: '-', description: 'Text label next to the checkbox.' },
+    { name: 'infoText', type: 'string', default: 'null', description: 'For instructional UI copy pertaining to the checkbox option' },
     { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' }
   ]
 }

--- a/docs/components/Checkbox.vue
+++ b/docs/components/Checkbox.vue
@@ -11,6 +11,7 @@
           :disabled="disabled"
           :checkbox-value="true"
           :checkbox-label="checkboxLabel"
+          info-text="This is some informative text"
         />
       </div>
       <div class="component-controls">

--- a/docs/components/Radio.js
+++ b/docs/components/Radio.js
@@ -4,28 +4,32 @@ export default {
   snippet:
         `<ao-radio
   v-for="radio in radios"
+  :id="radio.label"
   :key="radio.value"
-  :val="radio.value"
-  :name="radio.name"
-  :label="radio.name"
   v-model="selectedRadio"
+  :val="radio.value"
+  name="favouriteCharacter"
+  :label="radio.label"
+  :info-text="radio.infoText"
 />
 
 data() {
   return {
     radios: [
-      { name: 'Tandy', value: 'Tandy' },
-      { name: 'Carol', value: 'Carol' },
-      { name: 'Gail', value: 'Gail' },
-      { name: 'Erica', value: 'Erica' },
-      { name: 'Todd', value: 'Todd' }
+      { id: 'tandy', label: 'Tandy', value: 'Tandy', infoText: 'Tandy is...' },
+      { id: 'carol', label: 'Carol', value: 'Carol', infoText: "Carol is..." },
+      { id: 'gail', label: 'Gail', value: 'Gail' },
+      { id: 'erica', label: 'Erica', value: 'Erica' },
+      { id: 'todd', label: 'Todd', value: 'Todd' }
     ],
     selectedRadio: 'Tandy'
   }
 }`,
   apiRows: [
     { name: 'val', type: '[String, Number, Boolean], required', default: 'null', description: 'This prop defines the actual value of a radio button.' },
-    { name: 'disabled', type: 'Boolean', default: 'false', description: 'This prop defines if the modal will ve disabled.' },
-    { name: 'label', type: 'Boolean', default: 'false', description: 'This prop defines the label of the radio button.' }
+    { name: 'label', type: 'Boolean', default: 'false', description: 'This prop defines the label of the radio button.' },
+    { name: 'showLabel', type: 'Boolean', default: 'true', description: 'Allows hiding the label text' },
+    { name: 'infoText', type: 'string', default: 'null', description: 'For instructional UI copy pertaining to the radio option' },
+    { name: 'disabled', type: 'Boolean', default: 'false', description: 'Disables interaction with the component.' }
   ]
 }

--- a/docs/components/Radio.vue
+++ b/docs/components/Radio.vue
@@ -6,17 +6,24 @@
 
     <div slot="example">
       <div class="component-example">
-        <div class="component-example__display">
-          My favourite character is {{ selectedRadio }}
+        <label>
+          My Favourite Character
+        </label>
+        <div>
+          <ao-radio
+            v-for="radio in radios"
+            :id="radio.label"
+            :key="radio.value"
+            v-model="selectedRadio"
+            :val="radio.value"
+            name="favouriteCharacter"
+            :label="radio.label"
+            :info-text="radio.infoText"
+          />
         </div>
-        <ao-radio
-          v-for="radio in radios"
-          :key="radio.value"
-          v-model="selectedRadio"
-          :val="radio.value"
-          :name="radio.name"
-          :label="radio.name"
-        />
+        <ao-info-pair label="Output">
+          {{ selectedRadio }}
+        </ao-info-pair>
       </div>
     </div>
     <template slot="snippet">
@@ -42,11 +49,11 @@ export default {
     return {
       ...RadioDocumentation,
       radios: [
-        { name: 'Tandy', value: 'Tandy' },
-        { name: 'Carol', value: 'Carol' },
-        { name: 'Gail', value: 'Gail' },
-        { name: 'Erica', value: 'Erica' },
-        { name: 'Todd', value: 'Todd' }
+        { id: 'tandy', label: 'Tandy', value: 'Tandy', infoText: 'Tandy is the original Phil Miller' },
+        { id: 'carol', label: 'Carol', value: 'Carol', infoText: "Carol is Tandy's wife" },
+        { id: 'gail', label: 'Gail', value: 'Gail' },
+        { id: 'erica', label: 'Erica', value: 'Erica' },
+        { id: 'todd', label: 'Todd', value: 'Todd' }
       ],
       selectedRadio: 'Tandy'
     }

--- a/src/assets/styles/mixins/shared-checkbox-styles.scss
+++ b/src/assets/styles/mixins/shared-checkbox-styles.scss
@@ -12,8 +12,13 @@
       cursor: pointer;
     }
     
-    &__text {
+    &__content {
+      display: inline-block;
       font-weight: normal;
+      vertical-align: top;
+    }
+    
+    &__label-text {
     }
   
     &__input {
@@ -21,13 +26,19 @@
       line-height: normal;  
       padding: 0;
       margin: 0;
-      margin-right: 0.25rem;
+      margin-right: 0.5rem;
       position: relative;
       top: -1px;
     }
     
     &:last-of-type {
       margin-bottom: 1rem;
+    }
+    
+    &__info-text {
+      margin-bottom: $spacer-micro;
+      font-size: $font-size-sm;
+      color: $color-gray-30;
     }
   }
 }

--- a/src/components/AoCheckbox.vue
+++ b/src/components/AoCheckbox.vue
@@ -16,12 +16,20 @@
         @blur="emitBlur"
         @focus="emitFocus"
       >
-      <span
+      <div
         v-show="showLabel"
-        class="ao-checkbox__text"
+        class="ao-checkbox__content"
       >
-        {{ checkboxLabel }}
-      </span>
+        <span class="ao-checkbox__label-text">
+          {{ checkboxLabel }}
+        </span>
+        <p
+          v-if="infoText"
+          class="ao-checkbox__info-text"
+        >
+          {{ infoText }}
+        </p>
+      </div>
     </label>
   </div>
 </template>
@@ -54,6 +62,12 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+
+    infoText: {
+      default: null,
+      type: String,
+      required: false
     }
   },
 

--- a/src/components/AoRadio.vue
+++ b/src/components/AoRadio.vue
@@ -1,19 +1,33 @@
 <template>
-  <label class="ao-radio">
-    <input
-      v-model="checked"
-      v-bind="$attrs"
-      :value="val"
-      type="radio"
-      class="ao-radio__input"
-      @change="toggle"
-      @blur="emitBlur"
-      @focus="emitFocus"
-    >
-    <span class="ao-radio__text">
-      {{ label }}
-    </span>
-  </label>
+  <div class="ao-radio">
+    <label class="ao-radio__label">
+      <input
+        v-model="checked"
+        v-bind="$attrs"
+        :value="val"
+        :disabled="disabled"
+        type="radio"
+        class="ao-radio__input"
+        @change="toggle"
+        @blur="emitBlur"
+        @focus="emitFocus"
+      >
+      <div
+        v-show="showLabel"
+        class="ao-radio__content"
+      >
+        <span class="ao-radio__label-text">
+          {{ label }}
+        </span>
+        <p
+          v-if="infoText"
+          class="ao-radio__info-text"
+        >
+          {{ infoText }}
+        </p>
+      </div>
+    </label>
+  </div>
 </template>
 
 <script>
@@ -34,6 +48,22 @@ export default {
     label: {
       type: String,
       required: true
+    },
+
+    disabled: {
+      type: Boolean,
+      default: false
+    },
+
+    showLabel: {
+      type: Boolean,
+      default: true
+    },
+
+    infoText: {
+      default: null,
+      type: String,
+      required: false
     }
   },
 
@@ -72,11 +102,5 @@ export default {
 <style lang="scss">
 @import '../assets/styles/mixins/shared-checkbox-styles.scss';
 @include shared-checkbox-styles;
-
-.ao-radio {
-  &__input {
-    margin-right: 0.5rem;
-  }
-}
 
 </style>


### PR DESCRIPTION
# Link to Github Issue

#342, #343 

# Description

Add a prop for passing in contextual text to a radio or checkbox input, and clean up the radio docs page a bit.

**Looking for early review, still needs updates to the docs and, I assume, tests?**