### PR TITLE
AoCard: include slot for card actions

### DIFF
--- a/docs/components/Card.js
+++ b/docs/components/Card.js
@@ -2,7 +2,26 @@ export default {
   header: 'Card',
   description: 'The Card component allows you to group and organize related content - text, actions, even other Blaze components - into one seamless display.',
   snippet:
-        `<ao-card :title="'Title goes here'">
+`<ao-card title="Seashell Day">
+  <ao-button
+    slot="card-header-action"
+    subtle
+    small
+  >
+    <i class="material-icons">more_horiz</i>
+  </ao-button>
+  <ao-callout
+    slot="card-callout"
+    success
+  >
+    Great day for seashells
+  </ao-callout>
+  <div slot="card-header-toolbar">
+    <ao-checkbox
+      :checkbox-value="true"
+      checkbox-label="filter"
+    />
+  </div>
   <p>She sells seashells by the sea shore</p>
   <template slot="cardFooter">
     <ao-button primary>

--- a/docs/components/Card.vue
+++ b/docs/components/Card.vue
@@ -9,6 +9,30 @@
         <ao-card
           :title="titleText"
         >
+          <ao-button
+            v-if="showCardAction"
+            slot="card-header-action"
+            subtle
+            small
+          >
+            <i class="material-icons">more_horiz</i>
+          </ao-button>
+          <ao-callout
+            v-if="showCardCallout"
+            slot="card-callout"
+            success
+          >
+            {{ calloutText }}
+          </ao-callout>
+          <div
+            v-if="showCardToolbar"
+            slot="card-header-toolbar"
+          >
+            <ao-checkbox
+              :checkbox-value="true"
+              checkbox-label="filter"
+            />
+          </div>
           <p>{{ slotText }}</p>
           <template slot="cardFooter">
             <ao-button primary>
@@ -31,6 +55,27 @@
           :type="'text'"
           label="Card Content Text"
         />
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="showCardAction"
+            :checkbox-value="true"
+            checkbox-label="Show Card Action Slot"
+          />
+        </div>
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="showCardToolbar"
+            :checkbox-value="true"
+            checkbox-label="Show Card Toolbar Slot"
+          />
+        </div>
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="showCardCallout"
+            :checkbox-value="true"
+            checkbox-label="Show Card Callout Slot"
+          />
+        </div>
       </div>
     </div>
     <template slot="snippet">
@@ -55,8 +100,12 @@ export default {
   data () {
     return {
       ...CardDocumentation,
-      titleText: 'Title goes here',
-      slotText: 'She sells seashells by the sea shore'
+      titleText: 'Seashell Day',
+      calloutText: 'Great day for seashells',
+      slotText: 'She sells seashells by the sea shore',
+      showCardAction: true,
+      showCardToolbar: true,
+      showCardCallout: true
     }
   }
 }

--- a/src/components/AoCard.vue
+++ b/src/components/AoCard.vue
@@ -6,6 +6,7 @@
     >
       <h2 class="ao-card__title">
         {{ title }}
+        <slot name="card-header-action" />
       </h2>
       <div class="ao-card__toolbar">
         <slot name="card-header-toolbar" />
@@ -83,6 +84,10 @@ export default {
     font-size: $font-size-xl;
     font-weight: $font-weight-light;
     display: inline-block;
+
+    & > * {
+      vertical-align: bottom;
+    }
   }
 
   &__toolbar {


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/345

# Description

Include a slot on the AoCard component for card actions that would appear beside the title text

![Screen Shot 2019-07-12 at 2 18 24 PM](https://user-images.githubusercontent.com/6413467/61150458-7a53f500-a4b1-11e9-8a0b-7e33569aa703.png)
