### PR TITLE
AoTable: include ability for tooltips beside headers

### DIFF
--- a/docs/components/Table.js
+++ b/docs/components/Table.js
@@ -39,7 +39,7 @@ data () {
       { field: 'id', title: 'ID', sortable: true },
       { field: 'first_name', title: 'First Name', sortable: true, hidden: true },
       { field: 'last_name', title: 'Last Name', sortable: true, alignRight: true },
-      { field: 'friends', title: 'Friends', sortable: true }
+      { field: 'friends', title: 'Friends', sortable: true, tooltip: { text: 'Friendly friends', multiline: false, position: 'top' } }
     ],
     users: [
       { 'id': 1, 'first_name': 'Jesse', 'last_name': 'Simmons', 'friends': '44', selected: false },
@@ -84,7 +84,7 @@ methods: {
   apiRows: [
     { name: 'condensed', type: 'Boolean', default: 'false', description: 'When set to true, this prop reduces appropriate styling to make table look condensed.' },
     { name: 'headers', type: 'Array', default: 'null', description: 'This prop contains an array of objects with header title, field and a sortable boolean to determine if your data should be sorted by that header.' },
-    { name: 'headers > alignRight,<br /> hidden', type: 'Boolean', default: 'false', description: 'Include the <strong>alignRight</strong> property to align the header to the right side of the space given. <br />Include a <strong>hidden</strong> property to hide a given \'th\' header.' },
+    { name: 'headers > alignRight,<br /> hidden,<br /> tooltip', type: 'Boolean, Boolean, Object', default: 'false', description: 'Include the <strong>alignRight</strong> property to align the header to the right side of the space given. <br />Include a <strong>hidden</strong> property to hide a given \'th\' header. <br />Include the <strong>tooltip</strong> component beside the header with its own props.' },
     { name: 'isClickable', type: 'Boolean', default: 'false', description: 'When set to true, this prop adds appropriate styling to signify that the table and table rows are clickable.' },
     { name: 'isScrollable', type: 'Boolean', default: 'false', description: 'When set to true, this prop adds appropriate styling to make table body scroll on the y-axis if it hits a max-height.' },
     { name: 'maxHeight', type: 'String', default: '', description: 'Defines the max height of a table in pixels when <strong>isScrollable</strong> is true.' },

--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -178,7 +178,7 @@ export default {
         { field: 'id', title: 'ID', sortable: true },
         { field: 'first_name', title: 'First Name', sortable: true, hidden: this.hidden },
         { field: 'last_name', title: 'Last Name', sortable: true, alignRight: this.alignRight },
-        { field: 'friends', title: 'Friends', sortable: true }
+        { field: 'friends', title: 'Friends', sortable: true, tooltip: { text: 'Friendly friends', multiline: false, position: 'top' } }
       ]
     },
     partialSelection () {

--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -25,6 +25,13 @@
           >
             {{ columnHeader.title }}<span :class="isChevroned(columnHeader.field, columnHeader.sortable, columnHeader.hidden)" />
           </span>
+          <ao-tooltip
+            v-if="hasTooltip(columnHeader.tooltip)"
+            class="ao-table__tooltip-icon"
+            :text="columnHeader.tooltip.text"
+            :position="columnHeader.tooltip.position"
+            :multiline="columnHeader.tooltip.multiline"
+          />
         </th>
       </tr>
     </thead>
@@ -50,8 +57,13 @@
 
 <script>
 import { filterClasses } from './utils/component_utilities.js'
+import AoTooltip from './AoTooltip.vue'
 
 export default {
+  components: {
+    AoTooltip
+  },
+
   props: {
     headers: {
       type: Array,
@@ -181,6 +193,10 @@ export default {
       return sortable === true && hidden === false
     },
 
+    hasTooltip (tooltip) {
+      return tooltip && tooltip['text']
+    },
+
     getMaxHeight () {
       return {
         'max-height': this.maxHeight
@@ -275,6 +291,11 @@ $table-row-background-shaded: $color-gray-90;
   &__sort-icon {
     margin-left: $spacer-micro;
     top: 0;
+  }
+
+  &__tooltip-icon {
+    margin-left: $spacer-micro;
+    top: .2rem;
   }
 
   &__action-column {

--- a/tests/unit/AoTable.spec.js
+++ b/tests/unit/AoTable.spec.js
@@ -132,6 +132,22 @@ describe('Table', () => {
     expect(table.emitted().sortTable.length).toBe(5)
   })
 
+  it('tooltip', () => {
+    const tooltip = '.ao-table__tooltip-icon'
+    const table = mount(Table, {
+      propsData: {
+        headers: [
+          { field: 'field', title: 'Table Header', sortable: true, tooltip: { text: 'Tooltip Text', multiline: false, position: 'top' } }
+        ]
+      }
+    })
+    expect(
+      table
+        .find(tooltip)
+        .isVisible()
+    )
+  })
+
   it('nodata', () => {
     const noDataSelector = '.ao-table__nodata'
     const table = mount(Table, {


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/347

# Description

Include ability for tooltips beside headers

Looks like this

![Screen Shot 2019-07-12 at 4 01 12 PM](https://user-images.githubusercontent.com/6413467/61155216-534ff000-a4be-11e9-8c96-0049f98ba884.png)
