### PR TITLE
AoDropDown: Allow for direction props

### DIFF
--- a/docs/components/Dropdown.js
+++ b/docs/components/Dropdown.js
@@ -24,6 +24,7 @@ data () {
   }
 }`,
   apiRows: [
-    { name: 'showDropdown', type: 'Boolean', default: 'false', description: 'Hides or un-hides the dropdown.' }
+    { name: 'showDropdown', type: 'Boolean', default: 'false', description: 'Hides or un-hides the dropdown.' },
+    { name: 'direction', type: 'String (left or right)', default: 'left', description: 'Shows dropdown on left or right side' }
   ]
 }

--- a/src/components/AoCard.vue
+++ b/src/components/AoCard.vue
@@ -6,8 +6,10 @@
     >
       <h2 class="ao-card__title">
         {{ title }}
-        <slot name="card-header-action" />
       </h2>
+      <div class="ao-card__action">
+        <slot name="card-header-action" />
+      </div>
       <div class="ao-card__toolbar">
         <slot name="card-header-toolbar" />
       </div>
@@ -79,11 +81,17 @@ export default {
     }
   }
 
+  &__action {
+    position: relative;
+    display: inline-block;
+  }
+
   &__title {
     margin: 0;
     font-size: $font-size-xl;
     font-weight: $font-weight-light;
     display: inline-block;
+    padding-right: $spacer;
 
     & > * {
       vertical-align: bottom;
@@ -94,6 +102,8 @@ export default {
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
+    flex-grow: 1;
+    justify-content: flex-end;
 
     & .form-group {
       display: inline-block;

--- a/src/components/AoDropdown.vue
+++ b/src/components/AoDropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="showDropdown"
-    class="ao-dropdown"
+    :class="['ao-dropdown', computedDropdownDirection]"
   >
     <slot name="dropdown-items" />
   </div>
@@ -13,6 +13,20 @@ export default {
     showDropdown: {
       type: Boolean,
       default: false
+    },
+
+    direction: {
+      type: String,
+      default: 'left',
+      validator: (value) => {
+        return ['left', 'right'].indexOf(value) !== -1
+      }
+    }
+  },
+
+  computed: {
+    computedDropdownDirection () {
+      return `ao-dropdown--${this.direction}`
     }
   }
 }
@@ -30,9 +44,16 @@ export default {
   text-align: left;
   position: absolute;
   top: 100%;
-  right: 0px;
   margin-top: 3px;
   white-space: nowrap;
+
+  &--left {
+    right: 0;
+  }
+
+  &--right {
+    left: 0;
+  }
 }
 
 .ao-header-toolbar__controls > * > .ao-dropdown {

--- a/tests/unit/AoDropdown.spec.js
+++ b/tests/unit/AoDropdown.spec.js
@@ -10,5 +10,18 @@ describe('dropdown', () => {
       }
     })
     expect(wrapper.classes()).toContain('ao-dropdown')
+    expect(wrapper.classes()).toContain('ao-dropdown--left')
+  })
+
+  it('right direction', () => {
+    const wrapper = shallowMount(Dropdown, {
+      propsData: {
+        links: [],
+        showDropdown: true,
+        direction: 'right'
+      }
+    })
+    expect(wrapper.classes()).toContain('ao-dropdown')
+    expect(wrapper.classes()).toContain('ao-dropdown--right')
   })
 })


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/354

# Description

Allow for direction props for AoDropdown

Also allow the AoCard card-action to be in a div with position: relative and display: inline-block so that dropdowns here would work properly

Example of its usage

![Screen Shot 2019-07-17 at 5 52 51 PM](https://user-images.githubusercontent.com/6413467/61414354-b88b5300-a8bb-11e9-862b-ba9eb7852012.png)


