### PR TITLE
AoPopover Implementation

### DIFF
--- a/docs/components/Popover.js
+++ b/docs/components/Popover.js
@@ -1,0 +1,20 @@
+export default {
+  header: 'Popover',
+  description: 'This is a customizable popover component.',
+  snippet:
+`<ao-popover
+  position="bottom"
+  text="Search the database based on your customized query"
+>
+  <ao-input
+    type="text"
+    label="Search"
+    :show-label="false"
+    placeholder="Search here"
+  />
+</ao-popover>`,
+  apiRows: [
+    { name: 'position', type: 'String (bottom, left, top, right)', default: 'bottom', description: 'Shows popover at selected position.' },
+    { name: 'text', type: 'String', default: 'null', description: 'Text for popover.' }
+  ]
+}

--- a/docs/components/Popover.vue
+++ b/docs/components/Popover.vue
@@ -1,0 +1,78 @@
+<template>
+  <Layout>
+    <template slot="description">
+      <span v-html="description" />
+    </template>
+
+    <div slot="example">
+      <div class="component-example component-example__popover">
+        <ao-popover
+          :position="selectedPosition"
+          :text="popoverText"
+        >
+          <ao-input
+            type="text"
+            label="Search"
+            :show-label="false"
+            placeholder="Search here"
+          />
+        </ao-popover>
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-input
+            v-model="popoverText"
+            :type="'text'"
+            :label="'Popover Text'"
+          />
+        </div>
+        <div class="component-controls__group">
+          <ao-select
+            v-model="selectedPosition"
+            label="Position"
+          >
+            <option
+              v-for="prop in popoverPositions"
+              :key="prop.name"
+              :value="prop.value"
+            >
+              {{ prop.name }}
+            </option>
+          </ao-select>
+        </div>
+      </div>
+    </div>
+    <template slot="snippet">
+      <code>{{ snippet }}</code>
+    </template>
+    <template slot="api">
+      <ApiTable :rows="apiRows" />
+    </template>
+  </Layout>
+</template>
+
+<script>
+import Layout from '../layout/Layout'
+import ApiTable from '../helpers/ApiTable'
+import PopoverDocumentation from './Popover'
+
+export default {
+  components: {
+    Layout,
+    ApiTable
+  },
+  data () {
+    return {
+      ...PopoverDocumentation,
+      popoverText: 'Search the database based on your customized query',
+      popoverPositions: [
+        { value: 'bottom', name: 'bottom' },
+        { value: 'left', name: 'left' },
+        { value: 'top', name: 'top' },
+        { value: 'right', name: 'right' }
+      ],
+      selectedPosition: 'bottom'
+    }
+  }
+}
+</script>

--- a/src/assets/styles/settings/_variables.scss
+++ b/src/assets/styles/settings/_variables.scss
@@ -102,6 +102,7 @@ $zindex-modal:                1031;
 $zindex-alert:                1040;
 $zindex-spinner:              1050;
 $zindex-tooltip:              1060;
+$zindex-popover:              1060;
 
 $header-toolbar-height:       60px;
 

--- a/src/blaze-plugin.js
+++ b/src/blaze-plugin.js
@@ -17,6 +17,7 @@ import AoModal from './components/AoModal.vue'
 import AoMultiSelect from './components/AoMultiSelect.vue'
 import AoNavbar from './components/AoNavbar.vue'
 import AoPaginate from './components/AoPaginate.vue'
+import AoPopover from './components/AoPopover.vue'
 import AoRadio from './components/AoRadio.vue'
 import AoRadioButtonGroup from './components/AoRadioButtonGroup'
 import AoSectionHeader from './components/AoSectionHeader.vue'
@@ -49,6 +50,7 @@ const Blaze = {
     Vue.component('AoMultiSelect', AoMultiSelect)
     Vue.component('AoNavbar', AoNavbar)
     Vue.component('AoPaginate', AoPaginate)
+    Vue.component('AoPopover', AoPopover)
     Vue.component('AoRadio', AoRadio)
     Vue.component('AoRadioButtonGroup', AoRadioButtonGroup)
     Vue.component('AoSectionHeader', AoSectionHeader)

--- a/src/components/AoPopover.vue
+++ b/src/components/AoPopover.vue
@@ -1,0 +1,129 @@
+<template>
+  <div :class="[computedClasses, `ao-popover--${this.position}`]">
+    <slot />
+    <div class="ao-popover__container">
+      <span class="ao-popover__text">
+        {{ text }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { filterClasses } from './utils/component_utilities.js'
+
+export default {
+  props: {
+    text: {
+      type: String,
+      required: true,
+      default: null
+    },
+
+    position: {
+      type: String,
+      required: false,
+      default: 'bottom'
+    }
+  },
+
+  computed: {
+    computedClasses () {
+      const activeClasses = {
+        'ao-popover': true
+      }
+      return filterClasses(activeClasses)
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+$popover-distance: $spacer-micro; /* Defining a consistent distance from the object; */
+$popover-background-color: $color-white;
+$popover-transition: opacity .2s ease-in-out;
+$popover-width: 260px !default; /* Possible improvement would be the use its sibling's width */
+
+.ao-popover {
+  position: relative;
+  display: inline-block;
+  outline: none;
+
+  &__container {
+    position: absolute;
+    z-index: $zindex-popover;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+  }
+
+  &__text {
+    visibility: hidden;
+    position: absolute;
+    background: $popover-background-color;
+    font-size: $font-size-sm;
+    font-style: italic;
+    width: $popover-width;
+    color: $color-gray-20;
+    opacity: 0;
+    padding: 9px 14px;
+    transition: $popover-transition;
+    border-radius: $border-radius-base;
+    border: 1px solid $color-gray-60;
+  }
+
+  &--left &__container {
+    left: 0;
+    top: 50%;
+
+    .ao-popover__text {
+      right: 0;
+      transform: translateY(-50%);
+      margin-right: $popover-distance;
+    }
+  }
+
+  &--right &__container {
+    right: 0;
+    top: 50%;
+
+    .ao-popover__text {
+      left: 0;
+      transform: translateY(-50%);
+      margin-left: $popover-distance;
+    }
+  }
+
+  &--top &__container {
+    top: 0;
+
+    .ao-popover__text {
+      bottom: 0;
+      margin-bottom: $popover-distance;
+    }
+  }
+
+  &--bottom &__container {
+    bottom: 0;
+    margin-top: $spacer-micro !important;
+
+    .ao-popover__text {
+      top: 0;
+      margin-top: $popover-distance;
+    }
+  }
+
+  & * {
+    margin-bottom: 0;
+  }
+
+  &:focus-within &__container {
+    overflow: visible;
+  }
+
+  &:focus-within &__text {
+    visibility: visible;
+    opacity: 1;
+  }
+}
+</style>

--- a/src/router.js
+++ b/src/router.js
@@ -19,6 +19,7 @@ import DatePicker from '../docs/components/DatePicker.vue'
 import Navbar from '../docs/components/Navbar.vue'
 import Modal from '../docs/components/Modal.vue'
 import Paginate from '../docs/components/Paginate.vue'
+import Popover from '../docs/components/Popover.vue'
 import Radio from '../docs/components/Radio.vue'
 import RadioButtonGroup from '../docs/components/RadioButtonGroup.vue'
 import SectionHeader from '../docs/components/SectionHeader.vue'
@@ -63,6 +64,7 @@ export default new Router({
     { name: 'multiselect', path: '/multiselect', component: MultiSelect, meta: { title: 'Multi Select' } },
     { name: 'navbar', path: '/navbar', component: Navbar, meta: { title: 'Navbar' } },
     { name: 'paginate', path: '/paginate', component: Paginate, meta: { title: 'Paginate' } },
+    { name: 'popover', path: '/popover', component: Popover, meta: { title: 'Popover' } },
     { name: 'radio', path: '/radio', component: Radio, meta: { title: 'Radio' } },
     { name: 'radio button group', path: '/radio-button-group', component: RadioButtonGroup, meta: { title: 'Radio Button Group' } },
     { name: 'sectionheader', path: '/sectionheader', component: SectionHeader, meta: { title: 'Section Header' } },

--- a/tests/unit/AoPopover.spec.js
+++ b/tests/unit/AoPopover.spec.js
@@ -1,0 +1,25 @@
+import { mount } from '@vue/test-utils'
+import Popover from '@/components/AoPopover.vue'
+
+describe('AoPopover', () => {
+  it('create', () => {
+    const popover = mount(Popover, {
+      propsData: {
+        text: 'popover'
+      }
+    })
+    expect(popover.classes()).toContain('ao-popover')
+    expect(popover.classes()).toContain('ao-popover--bottom')
+    expect(popover.find('.ao-popover__text').text()).toBe('popover')
+  })
+
+  it('position', () => {
+    const popover = mount(Popover, {
+      propsData: {
+        text: 'popover',
+        position: 'top'
+      }
+    })
+    expect(popover.classes()).toContain('ao-popover--top')
+  })
+})


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/359

# Description

AoPopover Implementation

![Screen Shot 2019-07-22 at 4 33 45 PM](https://user-images.githubusercontent.com/6413467/61663380-7f2d5b80-ac9e-11e9-9eed-64c5acc08914.png)

### Usage

- Wrap ao-popover around an ao-input
- Focus the ao-input
- Text should popover based on the position

### Props

- position (string)
- text (string)

### Notes
- focus-within was used on the .ao-popover class to make opacity and visibility real