### PR TITLE
AoModal: remove unused row class from footer section

### DIFF
--- a/src/components/AoModal.vue
+++ b/src/components/AoModal.vue
@@ -34,9 +34,7 @@
               v-if="hasSlot('modal-footer')"
               class="ao-modal__footer"
             >
-              <div class="row">
-                <slot name="modal-footer" />
-              </div>
+              <slot name="modal-footer" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
# Link to Github Issue

https://github.com/AmpleOrganics/Blaze.vue/issues/361

# Description

Remove unused `row` class from footer section of AoModal.

This will prevent any conflicting classes from external CSS libraries or developer created styles that define their own global `row` class.