### PR TITLE
Fix header count to include selection column

### DIFF
--- a/docs/components/Table.vue
+++ b/docs/components/Table.vue
@@ -36,11 +36,15 @@
             <td>{{ user.last_name }}</td>
             <td>{{ user.friends }}</td>
           </tr>
-          <tr slot="table-footer">
+          <tr
+            v-if="!showNoDataText"
+            slot="table-footer"
+          >
             <td>
               <strong>Total</strong>
             </td>
             <td />
+            <td v-if="selectableTable" />
             <td />
             <td>
               <strong>230</strong>

--- a/src/components/AoTable.vue
+++ b/src/components/AoTable.vue
@@ -44,7 +44,7 @@
         v-if="showNoDataText"
         class="ao-table__nodata"
       >
-        <td :colspan="headers.length">
+        <td :colspan="totalColumns">
           {{ noDataText }}
         </td>
       </tr>
@@ -158,6 +158,9 @@ export default {
 
     computedVAlign () {
       return `ao-table--vertical-align-${this.vAlign}`
+    },
+    totalColumns () {
+      return this.headers.length + Number(this.selectableTable)
     }
   },
 


### PR DESCRIPTION
# Description

Adding `columnCount` as a computed property that takes `selectableTable` into account when spacing out the colspan for the `noDataText` table row. Also hides the Total row in the docs when `noDataText` is selected.