### PR TITLE
AoRadioButtonGroup: addition of a subtle class option

### DIFF
--- a/docs/components/RadioButtonGroup.js
+++ b/docs/components/RadioButtonGroup.js
@@ -22,7 +22,8 @@ data () {
 }`,
   apiRows: [
     { name: 'options', type: 'Array, required', description: 'this props provides radio options for the radio buttons, check the example for how they should be structured' },
-    { name: 'name', type: 'String, required', description: 'this prop links each radio button together' }
+    { name: 'name', type: 'String, required', description: 'this prop links each radio button together' },
+    { name: 'subtle', type: 'Boolean', default: false, description: 'Displays a more subtle version of the default radio button group.' }
   ]
 
 }

--- a/docs/components/RadioButtonGroup.vue
+++ b/docs/components/RadioButtonGroup.vue
@@ -12,8 +12,18 @@
         <ao-radio-button-group
           v-model="selectedRadio"
           :options="radioButtons"
+          :subtle="subtle"
           name="test"
         />
+      </div>
+      <div class="component-controls">
+        <div class="component-controls__group">
+          <ao-checkbox
+            v-model="subtle"
+            :checkbox-value="true"
+            checkbox-label="Subtle"
+          />
+        </div>
       </div>
     </div>
     <template slot="snippet">
@@ -41,10 +51,11 @@ export default {
       ...RadioButtonGroupDocumentation,
       radioButtons: [
         { name: 'Tandy', value: 'Tandy' },
-        { name: 'Other Guy', value: 'Other' },
+        { name: 'Other Guy', value: 'Other Guy' },
         { name: 'Todd', value: 'Todd' }
       ],
-      selectedRadio: ''
+      selectedRadio: '',
+      subtle: false
     }
   }
 }

--- a/src/components/AoRadioButtonGroup.vue
+++ b/src/components/AoRadioButtonGroup.vue
@@ -19,7 +19,7 @@
       >
       <label
         :for="option.value"
-        class="ao-radio-button-group__option-input-label"
+        :class="computedLabelClass"
         @click="select(option.value)"
       >
         {{ option.name }}
@@ -29,6 +29,8 @@
 </template>
 
 <script>
+import { filterClasses } from './utils/component_utilities.js'
+
 export default {
   inheritAttrs: false,
   props: {
@@ -45,12 +47,27 @@ export default {
     value: {
       type: [Number, String, Boolean],
       required: true
+    },
+
+    subtle: {
+      type: Boolean,
+      default: false
     }
   },
 
   data () {
     return {
       currentValue: null
+    }
+  },
+
+  computed: {
+    computedLabelClass () {
+      const activeClasses = {
+        'ao-radio-button-group__option-input-label': true,
+        'ao-radio-button-group__option-input-label--subtle': this.subtle
+      }
+      return filterClasses(activeClasses)
     }
   },
 
@@ -107,6 +124,12 @@ export default {
     background-color: $color-gray-90;
     border-color: $color-gray-60;
     color: $font-color-secondary;
+
+    &--subtle {
+      font-weight: inherit;
+      font-size: $font-size-sm;
+      min-height: 1em;
+    }
   }
 
   &__option:first-of-type > &__option-input-label {
@@ -138,13 +161,20 @@ export default {
       cursor: not-allowed !important;
     }
 
-    &:checked + &-label,
-    &:checked:active + &-label,
-    &:checked:hover + &-label {
-      background-color: $color-success;
-      border-color: $color-success;
-      box-shadow: $shadow-none;
-      color: white;
+    &:checked, &:checked:active, &:checked:hover {
+
+      + .ao-radio-button-group__option-input-label {
+        background-color: $color-success;
+        border-color: $color-success;
+        box-shadow: $shadow-none;
+        color: white;
+
+        &--subtle {
+          background-color: $color-gray-80;
+          border-color: $color-gray-60;
+          color: $font-color-secondary;
+        }
+      }
     }
   }
 }

--- a/tests/unit/AoRadioButtonGroup.spec.js
+++ b/tests/unit/AoRadioButtonGroup.spec.js
@@ -30,6 +30,19 @@ describe('Radio', () => {
     expect(radioButtonGroup.find('.ao-radio-button-group__option-input:checked').element.value).toBe(selectedOptionValue)
   })
 
+  it('subtle', () => {
+    const selectedOptionValue = options[1].value
+    const radioButtonGroup = mount(RadioButtonGroup, {
+      propsData: {
+        options: options,
+        value: selectedOptionValue,
+        name: 'name',
+        subtle: true
+      }
+    })
+    expect(radioButtonGroup.find('.ao-radio-button-group__option-input-label--subtle').isVisible()).toBe(true)
+  })
+
   it('emits on option selection', () => {
     const selectedOptionValue = options[1].value
     const radioButtonGroup = mount(RadioButtonGroup, {


### PR DESCRIPTION
# Description

Addition of a subtle class option to the AoRadioButtonGroup component

This makes it slightly smaller in height and when an option is checked, it will turn grey-ish instead of the success green with the same secondary font color.