### PR TITLE
Bump release to 3.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.7 (2020-06-02)
+
+## Changes
+
+To improve accessibility, link style has been changed to underline and some colours have been adjusted for increased contrast [#382](https://github.com/AmpleOrganics/Blaze.vue/pull/382)
+
 # 3.6.6 (2020-01-14)
 
 ## New

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze-vue",
-  "version": "3.6.6",
+  "version": "3.6.7",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve --open",


### PR DESCRIPTION
# 3.6.7 (2020-06-02)

## Changes

To improve accessibility, link style has been changed to underline and some colours have been adjusted for increased contrast [#382](https://github.com/AmpleOrganics/Blaze.vue/pull/382)