### PR TITLE
Update link styles for accessibility in 3.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.8 (2020-06-09)
+
+## Changes
+
+Link underlines have been removed from some link styles. Breadcrumbs remain underlined as they are always presented alongside non-clickable text elements. [#385](https://github.com/AmpleOrganics/Blaze.vue/pull/385)
+
 # 3.6.7 (2020-06-02)
 
 ## Changes

--- a/docs/layout/LayoutSidebar.vue
+++ b/docs/layout/LayoutSidebar.vue
@@ -39,7 +39,7 @@ export default {
   }
 
   &__item-link {
-    text-decoration: underline;
+    text-decoration: none;
   }
 
   .router-link-active {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze-vue",
-  "version": "3.6.7",
+  "version": "3.6.8",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve --open",

--- a/src/assets/styles/global/_elements.scss
+++ b/src/assets/styles/global/_elements.scss
@@ -39,10 +39,10 @@ small {
 
 a {
   color: $font-color-link;
-  text-decoration: underline;
 
   &:hover {
     color: $font-color-link-hover;
+    text-decoration: underline;
   }
 }
 


### PR DESCRIPTION
# Link to Github Issue

https://ampleorganics.atlassian.net/browse/HUM-1462

# Description

Link underlines have been removed from some link styles. Breadcrumbs remain underlined as they are always presented alongside non-clickable text elements. 