### PR TITLE
HUM-1574: update AORadio to allow null prop

### DIFF
--- a/src/components/AoRadio.vue
+++ b/src/components/AoRadio.vue
@@ -36,12 +36,12 @@ export default {
   props: {
     // consistant naming and proxy for vue magic
     value: {
-      type: [String, Number, Boolean],
+      type: [String, Number, Boolean, Object],
       required: true
     },
 
     val: {
-      type: [String, Number, Boolean],
+      type: [String, Number, Boolean, Object],
       required: true
     },
 


### PR DESCRIPTION
# Link to Github Issue

https://ampleorganics.atlassian.net/browse/HUM-1574

https://github.com/AmpleOrganics/ao-webapp/pull/2539

# Description

Console errors due to AORadio not accepting null prop
