### PR TITLE
Adjust for resize text accessibility requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.9 (2020-07-31)
+
+## Changes
+
+Converting heights and widths to use rem rather than px; Resizing text using browser accessibility features causes overlap and other visual issues when sized in pixels.
+
 # 3.6.8 (2020-06-09)
 
 ## Changes

--- a/docs/components/FileUpload.vue
+++ b/docs/components/FileUpload.vue
@@ -90,6 +90,6 @@ export default {
 
 <style lang="scss" scoped>
 .component-example__file-upload {
-  height: 100px;
+  height: 6.25rem;
 }
 </style>

--- a/docs/layout/Layout.vue
+++ b/docs/layout/Layout.vue
@@ -92,21 +92,21 @@ export default {
   &__container {
     display: flex;
     width: 100%;
-    max-width: 1170px;
+    max-width: 73.125rem;
     margin-right: auto;
   }
 
   &__sidebar-container {
     width: 25%;
     padding: $spacer;
-    padding-top: $header-toolbar-height + $spacer-px;
+    padding-top: $header-toolbar-height + $spacer;
   }
 
   &__content-container {
     width: 75%;
     max-width: 75rem;
     padding: $spacer;
-    padding-top: $header-toolbar-height + $spacer-px;
+    padding-top: $header-toolbar-height + $spacer;
     > * {
       margin-bottom: 1rem;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze-vue",
-  "version": "3.6.8",
+  "version": "3.6.9",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve --open",

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@ export default {
 
 #router-container {
   padding: $spacer;
-  padding-top: $header-toolbar-height + $spacer-px;
+  padding-top: $header-toolbar-height + $spacer;
 }
 
 #app {

--- a/src/assets/styles/mixins/shared-input-styles.scss
+++ b/src/assets/styles/mixins/shared-input-styles.scss
@@ -4,7 +4,7 @@
   .ao-form-control {
     display: block;
     width: 100%;
-    min-width: 60px;
+    min-width: 3.75rem;
     max-width: 100%;
     height: $input-height-base;
     font-family: $font-family-primary;

--- a/src/assets/styles/settings/_variables.scss
+++ b/src/assets/styles/settings/_variables.scss
@@ -56,7 +56,6 @@ $color-gray-90:               #f7f7f9;
 // Spacing & Sizing
 //
 
-$spacer-px:                   15px;
 $spacer-micro:                .25rem;
 $spacer-xs:                   .5rem;
 $spacer-sm:                   .75rem;
@@ -69,12 +68,12 @@ $spacer-lg:                   1.5rem;
 
 $font-family-primary:         'Lato', arial, sans-serif;
 
-$font-size-base:              16px; // This becomes 1rem
-$font-size-xs:                12px;
-$font-size-sm:                14px;
-$font-size-lg:                20px;
-$font-size-xl:                28px;
-$font-size-xxl:               34px;
+$font-size-base:              1rem;
+$font-size-xs:                0.75rem;
+$font-size-sm:                0.875rem;
+$font-size-lg:                1.25rem;
+$font-size-xl:                1.75rem;
+$font-size-xxl:               2.125rem;
 
 $font-weight-light:           200;
 $font-weight-bold:            700;
@@ -104,7 +103,7 @@ $zindex-spinner:              1050;
 $zindex-tooltip:              1060;
 $zindex-popover:              1060;
 
-$header-toolbar-height:       60px;
+$header-toolbar-height:       3.75rem;
 
 //
 // General UI Styles
@@ -124,9 +123,9 @@ $shadow-inset:                inset 0 2px 3px rgba(0, 0, 0, 0.05);
 
 $transition-base:             0.2s ease;
 
-$header-icon-height:          24px;
+$header-icon-height:          1.5rem;
 
-$browser-scrollbar-width:     17px; // https://codepen.io/sambible/post/browser-scrollbar-widths
+$browser-scrollbar-width:     1.0625rem; // https://codepen.io/sambible/post/browser-scrollbar-widths
 
 //
 // Inputs & Buttons

--- a/src/components/AoButton.vue
+++ b/src/components/AoButton.vue
@@ -215,7 +215,7 @@ export default {
 
  &--jumbo {
    width: 100%;
-   height: 80px;
+   height: 5rem;
    margin-left: 0;
  }
 

--- a/src/components/AoDropdown.vue
+++ b/src/components/AoDropdown.vue
@@ -45,7 +45,7 @@ export default {
   background: $color-white;
   box-shadow: $shadow, $shadow-subtle;
   border: $border-gray-50;
-  min-width: 144px;
+  min-width: 9rem;
   text-align: left;
   position: absolute;
   top: 100%;
@@ -65,11 +65,11 @@ export default {
   }
 
   &--medium {
-    width: 240px;
+    width: 15rem;
   }
 
   &--large {
-    width: 320px;
+    width: 20rem;
   }
 
   & > hr {

--- a/src/components/AoModal.vue
+++ b/src/components/AoModal.vue
@@ -167,15 +167,15 @@ export default {
   }
 
   &--large &__content {
-    max-width: 800px;
+    max-width: 50rem;
   }
 
   &--medium &__content {
-    max-width: 600px;
+    max-width: 37.5rem;
   }
 
   &--small &__content {
-    max-width: 400px;
+    max-width: 25rem;
   }
 }
 

--- a/src/components/AoMultiSelect.vue
+++ b/src/components/AoMultiSelect.vue
@@ -207,7 +207,7 @@ export default {
     display: flex;
     flex-direction: column;
     border: $border-gray-50;
-    min-width: 140px;
+    min-width: 8.75rem;
     text-align: left;
     margin-top: 3px;
     white-space: nowrap;


### PR DESCRIPTION
# Link to JIRA

https://ampleorganics.atlassian.net/browse/HUM-1464

# Description

Converting heights and widths to use rem rather than px; Resizing text using browser accessibility features causes overlap and other visual issues when sized in pixels.