### PR TITLE
HUM-1499 - accessibility improvement - form elements must have labels

### DIFF
--- a/src/components/AoInput.vue
+++ b/src/components/AoInput.vue
@@ -22,18 +22,20 @@
       >
         {{ prepend }}
       </span>
-      <input
-        v-bind="$attrs"
-        :class="['ao-form-control', {'ao-form-control--invalid': invalid }, computedSize]"
-        :disabled="disabled || disableAll"
-        :value="value"
-        :type="type"
-        :name="name"
-        @change="emitChange"
-        @input="emitInput"
-        @blur="emitBlur"
-        @focus="emitFocus"
-      >
+      <label>
+        <input
+          v-bind="$attrs"
+          :class="['ao-form-control', {'ao-form-control--invalid': invalid }, computedSize]"
+          :disabled="disabled || disableAll"
+          :value="value"
+          :type="type"
+          :name="name"
+          @change="emitChange"
+          @input="emitInput"
+          @blur="emitBlur"
+          @focus="emitFocus"
+        >
+      </label>
       <span
         v-if="hasIconAddon"
         :class="[iconClass, { 'ao-input__icon--clickable': hasIconClickableClass }]"

--- a/src/components/AoSelect.vue
+++ b/src/components/AoSelect.vue
@@ -10,25 +10,27 @@
       <slot name="tooltip" />
     </div>
     <div class="ao-input">
-      <select
-        :value="selected"
-        :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control', computedSize]"
-        :disabled="disabled || disableAll"
-        :name="name"
-        @change="emitChange"
-        @blur="emitBlur"
-        @focus="emitFocus"
-      >
-        <option
-          v-if="placeholder"
-          :value="null"
-          disabled
-          selected
+      <label>
+        <select
+          :value="selected"
+          :class="[{'ao-form-control--invalid': invalid }, 'ao-form-control', computedSize]"
+          :disabled="disabled || disableAll"
+          :name="name"
+          @change="emitChange"
+          @blur="emitBlur"
+          @focus="emitFocus"
         >
-          {{ placeholder }}
-        </option>
-        <slot />
-      </select>
+          <option
+            v-if="placeholder"
+            :value="null"
+            disabled
+            selected
+          >
+            {{ placeholder }}
+          </option>
+          <slot />
+        </select>
+      </label>
     </div>
     <span
       v-show="invalidMessage && invalid"

--- a/src/components/AoTextArea.vue
+++ b/src/components/AoTextArea.vue
@@ -9,18 +9,20 @@
       </label>
       <slot name="tooltip" />
     </div>
-    <textarea
-      v-bind="$attrs"
-      :class="{'ao-form-control--invalid': invalid }"
-      :value="value"
-      :disabled="disabled || disableAll"
-      :name="name"
-      class="ao-form-control"
-      @input="emitInput"
-      @blur="emitBlur"
-      @focus="emitFocus"
-      @change="emitChange"
-    />
+    <label>
+      <textarea
+        v-bind="$attrs"
+        :class="{'ao-form-control--invalid': invalid }"
+        :value="value"
+        :disabled="disabled || disableAll"
+        :name="name"
+        class="ao-form-control"
+        @input="emitInput"
+        @blur="emitBlur"
+        @focus="emitFocus"
+        @change="emitChange"
+      />
+    </label>
     <span
       v-show="invalidMessage && invalid"
       class="ao-form-group__invalid-message"


### PR DESCRIPTION
Accessibility improvement  - info and relationship: form elements must have labels

reference:
https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html
https://dequeuniversity.com/rules/axe/3.5/label