### PR TITLE
Bump version to 3.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.11 (2020-08-24)
+
+## Changes
+
+Removing redundant label tag from ao-select component [#397](https://github.com/AmpleOrganics/Blaze.vue/pull/397)
+
 # 3.6.10 (2020-08-24)
 
 ## Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze-vue",
-  "version": "3.6.10",
+  "version": "3.6.11",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve --open",


### PR DESCRIPTION
# 3.6.11 (2020-08-24)

## Changes

Removing redundant label tag from ao-select component [#397](https://github.com/AmpleOrganics/Blaze.vue/pull/397)
