### PR TITLE
Bump version to 3.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.12 (2020-08-25)
+
+## Changes
+
+Adding ring color for focus on ao-radio-button-group component for chrome [#399](https://github.com/AmpleOrganics/Blaze.vue/pull/399)
+
 # 3.6.11 (2020-08-24)
 
 ## Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze-vue",
-  "version": "3.6.11",
+  "version": "3.6.12",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve --open",


### PR DESCRIPTION
# 3.6.12 (2020-08-25)

## Changes

Adding ring color for focus on ao-radio-button-group component for chrome [#399](https://github.com/AmpleOrganics/Blaze.vue/pull/399)
