### PR TITLE
Fixing error makes ao-radio-button-group component does not work

### DIFF
--- a/src/components/AoRadioButtonGroup.vue
+++ b/src/components/AoRadioButtonGroup.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="ao-radio-button-group">
     <div
-      v-for="option in options"
+      v-for="(option, index) in options"
       :key="option.value"
       class="ao-radio-button-group__option"
     >
       <input
-        :id="uniqId"
+        :id="`${uniqId}_${index}`"
         v-bind="$attrs"
         :value="option.value"
         :checked="isChecked(option.value)"
@@ -18,7 +18,7 @@
         @focus="emitFocus"
       >
       <label
-        :for="uniqId"
+        :for="`${uniqId}_${index}`"
         class="ao-radio-button-group__option-input-label"
         @click="select(option.value)"
       >


### PR DESCRIPTION
Fixing error `ao-radio-button-group` doesn't work

# Description

All input in the radio options has the same `id` value which prevents the user from selecting other options.