### PR TITLE
Bump version to 3.6.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.13 (2020-09-08)
+
+## Changes
+
+Fixing error makes ao-radio-button-group component does not work [#401](https://github.com/AmpleOrganics/Blaze.vue/pull/401)
+
 # 3.6.12 (2020-08-25)
 
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Changes
 
-Fixing error makes ao-radio-button-group component does not work [#401](https://github.com/AmpleOrganics/Blaze.vue/pull/401)
+Fix an issue in radio button group caused by duplicated element IDs [#401](https://github.com/AmpleOrganics/Blaze.vue/pull/401)
 
 # 3.6.12 (2020-08-25)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze-vue",
-  "version": "3.6.12",
+  "version": "3.6.13",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve --open",


### PR DESCRIPTION
# 3.6.13 (2020-09-08)

## Changes

Fix an issue in radio button group caused by duplicated element IDs [#401](https://github.com/AmpleOrganics/Blaze.vue/pull/401)