### PR TITLE
Adding extra large size to ao-modal

### DIFF
--- a/src/components/AoModal.vue
+++ b/src/components/AoModal.vue
@@ -58,7 +58,7 @@ export default {
       type: String,
       default: 'medium',
       validator: function (value) {
-        return ['small', 'medium', 'large'].indexOf(value) !== -1
+        return ['small', 'medium', 'large', 'extra-large'].indexOf(value) !== -1
       }
     },
 
@@ -164,6 +164,10 @@ export default {
     padding: $spacer;
     text-align: right;
     border-top: 1px solid $color-gray-70;
+  }
+
+  &--extra-large &__content {
+    max-width: 65rem;
   }
 
   &--large &__content {


### PR DESCRIPTION
# Link to Github Issue

Adding extra large size option to ao-modal with width = 65rem

# Description

<img width="1393" alt="Screen Shot 2020-10-01 at 5 16 42 PM" src="https://user-images.githubusercontent.com/55992227/94864387-e51c8380-0409-11eb-8d5c-788097fd8b75.png">
