### PR TITLE
Bump version to 3.6.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.6.14 (2020-10-05)
+
+## Changes
+
+Adding extra-large size to ao-modal [#406](https://github.com/AmpleOrganics/Blaze.vue/pull/406)
+
 # 3.6.13 (2020-09-08)
 
 ## Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blaze-vue",
-  "version": "3.6.13",
+  "version": "3.6.14",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve --open",


### PR DESCRIPTION
# 3.6.14 (2020-10-05)

## Changes

Adding extra-large size to ao-modal [#406](https://github.com/AmpleOrganics/Blaze.vue/pull/406)