### PR TITLE
new feature on accessibility for radio label

### DIFF
--- a/src/components/AoRadio.vue
+++ b/src/components/AoRadio.vue
@@ -113,6 +113,7 @@ export default {
 @import '../assets/styles/mixins/shared-checkbox-styles.scss';
 @include shared-checkbox-styles;
 .ao-radio__label-text-default{
-  font-size: 0
+  font-size: 0;
+  margin-bottom: 0;
 }
 </style>

--- a/src/components/AoRadio.vue
+++ b/src/components/AoRadio.vue
@@ -1,36 +1,43 @@
 <template>
   <div class="ao-radio">
-    <label class="ao-radio__label">
-      <input
-        v-model="checked"
-        v-bind="$attrs"
-        :value="val"
-        :disabled="disabled"
-        type="radio"
-        class="ao-radio__input"
-        @change="toggle"
-        @blur="emitBlur"
-        @focus="emitFocus"
-      >
-      <div
-        v-show="showLabel"
-        class="ao-radio__content"
-      >
-        <span class="ao-radio__label-text">
-          {{ label }}
-        </span>
-        <p
-          v-if="infoText"
-          class="ao-radio__info-text"
-        >
-          {{ infoText }}
-        </p>
-      </div>
+    <input
+      :id="uniqId"
+      v-model="checked"
+      v-bind="$attrs"
+      :value="val"
+      :disabled="disabled"
+      type="radio"
+      class="ao-radio__input"
+      @change="toggle"
+      @blur="emitBlur"
+      @focus="emitFocus"
+    >
+    <label
+      :for="uniqId"
+      class="ao-radio__label-text-default"
+    >
+      {{ label }}
     </label>
+    <div
+      v-show="showLabel"
+      class="ao-radio__content"
+    >
+      <span class="ao-radio__label-text">
+        {{ label }}
+      </span>
+      <p
+        v-if="infoText"
+        class="ao-radio__info-text"
+      >
+        {{ infoText }}
+      </p>
+    </div>
   </div>
 </template>
 
 <script>
+import { getUniqId } from './utils/component_utilities.js'
+
 export default {
   inheritAttrs: false,
   props: {
@@ -74,6 +81,9 @@ export default {
   },
 
   computed: {
+    uniqId () {
+      return getUniqId()
+    },
     checked: {
       get () { return this.value },
       set (val) {
@@ -102,5 +112,7 @@ export default {
 <style lang="scss">
 @import '../assets/styles/mixins/shared-checkbox-styles.scss';
 @include shared-checkbox-styles;
-
+.ao-radio__label-text-default{
+  font-size: 0
+}
 </style>


### PR DESCRIPTION
https://akerna.atlassian.net/browse/HM-251

input radio elements must have labels.

![Screen Shot 2021-02-04 at 2 39 15 PM](https://user-images.githubusercontent.com/6337900/106946199-cf400780-66f6-11eb-98cb-0a9acd16f54d.png)
