### PR TITLE
Add focus trap to ao-modal component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@
 Ample Organics Component Library
 
 ## Documentation
-Run `yarn serve` the documentation should open in your broswer at `http://localhost:8080/`
+Run `yarn serve`, the documentation will open in your browser at `http://localhost:8080/`.
 
 ## Install
 Install the package using npm/yarn:
 
 ``` sh
-  yarn add blaze-vue
+  yarn add blaze-vue focus-trap focus-trap-vue
 ```
 ``` sh
-  npm i blaze-vue
+  npm i blaze-vue focus-trap focus-trap-vue
 ```
 
 ## Using in your application
+
 In your main.js/index.js add the following lines:
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -10,15 +10,14 @@
     "build:lib": "vue-cli-service build --target lib --name blaze-vue src/blaze-plugin.js",
     "lint:css": "stylelint 'src/**/*.vue' && stylelint 'docs/**/*.vue'",
     "prepublishOnly": "npm run build:lib && sh .post-build-copy.sh",
-    "test:unit": "vue-cli-service test:unit"
+    "test:unit": "vue-cli-service test:unit",
+    "prepare": "install-peers"
   },
   "main": "dist/blaze-vue.common.js",
   "files": [
     "dist"
   ],
   "dependencies": {
-    "focus-trap": "^6.4.0",
-    "focus-trap-vue": "^1.1.1",
     "vue": "^2.5.16"
   },
   "devDependencies": {
@@ -35,6 +34,7 @@
     "chai": "^4.1.2",
     "eslint": "^5.16.0",
     "eslint-plugin-vue": "^5.0.0",
+    "install-peers-cli": "^2.2.0",
     "lint-staged": "^8.1.5",
     "lodash.orderby": "^4.6.0",
     "lodash.uniqueid": "^4.0.1",
@@ -73,5 +73,9 @@
       "vue-cli-service lint docs",
       "git add"
     ]
+  },
+  "peerDependencies": {
+    "focus-trap": "^6.4.0",
+    "focus-trap-vue": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "dist"
   ],
   "dependencies": {
+    "focus-trap": "^6.4.0",
+    "focus-trap-vue": "^1.1.1",
     "vue": "^2.5.16"
   },
   "devDependencies": {

--- a/src/components/AoModal.vue
+++ b/src/components/AoModal.vue
@@ -1,52 +1,62 @@
 <template>
   <transition name="slide-fade">
     <div class="ao-modal-mask">
-      <div
-        ref="modal"
-        class="ao-modal"
-        tabindex="0"
-        @click.self="closeModal"
-        @keyup.esc.stop="closeModal"
+      <focus-trap
+        v-model="trapActive"
+        :escape-deactivates="false"
       >
         <div
-          :class="computedModalSize"
+          ref="modal"
+          class="ao-modal"
+          tabindex="-1"
           @click.self="closeModal"
+          @keyup.esc.stop="closeModal"
         >
-          <div class="ao-modal__content">
-            <div :class="computedHeaderClass">
-              <h2 class="ao-modal__header-text">
-                {{ headerText }}
-              </h2>
-            </div>
-            <div
-              v-if="hasSlot('modal-toolbar')"
-              class="ao-modal__toolbar"
-            >
-              <slot name="modal-toolbar" />
-            </div>
-            <div
-              v-if="hasSlot('modal-body')"
-              class="ao-modal__body"
-            >
-              <slot name="modal-body" />
-            </div>
-            <div
-              v-if="hasSlot('modal-footer')"
-              class="ao-modal__footer"
-            >
-              <slot name="modal-footer" />
+          <div
+            :class="computedModalSize"
+            @click.self="closeModal"
+          >
+            <div class="ao-modal__content">
+              <div :class="computedHeaderClass">
+                <h2 class="ao-modal__header-text">
+                  {{ headerText }}
+                </h2>
+              </div>
+              <div
+                v-if="hasSlot('modal-toolbar')"
+                class="ao-modal__toolbar"
+              >
+                <slot name="modal-toolbar" />
+              </div>
+              <div
+                v-if="hasSlot('modal-body')"
+                class="ao-modal__body"
+              >
+                <slot name="modal-body" />
+              </div>
+              <div
+                v-if="hasSlot('modal-footer')"
+                class="ao-modal__footer"
+              >
+                <slot name="modal-footer" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </focus-trap>
     </div>
   </transition>
 </template>
 
 <script>
 import { filterClasses } from './utils/component_utilities.js'
+import { FocusTrap } from 'focus-trap-vue'
 
 export default {
+  components: {
+    FocusTrap
+  },
+
   props: {
     headerText: {
       type: String,
@@ -73,6 +83,12 @@ export default {
     }
   },
 
+  data () {
+    return {
+      trapActive: false
+    }
+  },
+
   computed: {
     computedHeaderClass () {
       const activeClasses = {
@@ -89,8 +105,12 @@ export default {
   },
 
   mounted () {
-    // this sets focus on the modal so that the onEsc() functions as expected
-    this.$refs.modal.focus()
+    // focus-trap handles focusing the modal (and returning focus when it closes).
+    this.trapActive = true
+  },
+
+  beforeDestroy () {
+    this.trapActive = false
   },
 
   methods: {
@@ -98,9 +118,9 @@ export default {
       return !!this.$slots[slotName]
     },
     closeModal () {
-      // This only affects clicking outside the modal and pressing 'esc' key
-      // if you want to close the modal, the parent of the component shoud maniupulate a showModal
-      // variable that is linked to a v-if and :show
+      // This only affects clicking outside the modal and pressing 'esc' key.
+      // If you want to close the modal, the parent of the component should manipulate a showModal
+      // variable that is linked to a v-if and :show.
       this.$emit('modalClose')
     }
   }

--- a/tests/unit/AoModal.spec.js
+++ b/tests/unit/AoModal.spec.js
@@ -1,9 +1,9 @@
-import { mount } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import Modal from '@/components/AoModal.vue'
 
 describe('Modal', () => {
   it('create', () => {
-    const modal = mount(Modal, {
+    const modal = shallowMount(Modal, {
       propsData: {
         headerText: 'test'
       }
@@ -14,7 +14,7 @@ describe('Modal', () => {
   })
 
   it('small size', () => {
-    const modal = mount(Modal, {
+    const modal = shallowMount(Modal, {
       propsData: {
         headerText: 'test0',
         size: 'small'
@@ -25,7 +25,7 @@ describe('Modal', () => {
   })
 
   it('medium size', () => {
-    const modal = mount(Modal, {
+    const modal = shallowMount(Modal, {
       propsData: {
         headerText: 'test1',
         size: 'medium'
@@ -36,7 +36,7 @@ describe('Modal', () => {
   })
 
   it('large size', () => {
-    const modal = mount(Modal, {
+    const modal = shallowMount(Modal, {
       propsData: {
         headerText: 'test1',
         size: 'large'
@@ -47,7 +47,7 @@ describe('Modal', () => {
   })
 
   it('destructive', () => {
-    const modal = mount(Modal, {
+    const modal = shallowMount(Modal, {
       propsData: {
         headerText: 'test2',
         destructive: true
@@ -58,7 +58,7 @@ describe('Modal', () => {
   })
 
   it('caution', () => {
-    const modal = mount(Modal, {
+    const modal = shallowMount(Modal, {
       propsData: {
         headerText: 'test3',
         caution: true
@@ -69,7 +69,7 @@ describe('Modal', () => {
   })
 
   it('emit', () => {
-    const modal = mount(Modal, {
+    const modal = shallowMount(Modal, {
       propsData: {
         headerText: 'test'
       }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,13 @@
 const fs = require('fs')
 
+// Only define as externals for production builds
+const webpackProductionConfig = {
+  externals: {
+    'focus-trap': 'focus-trap',
+    'focus-trap-vue': 'focus-trap-vue'
+  }
+}
+
 module.exports = {
   lintOnSave: undefined,
   css: {
@@ -12,5 +20,6 @@ module.exports = {
       }
     }
   },
+  configureWebpack: process.env.NODE_ENV === 'production' ? webpackProductionConfig : {},
   parallel: true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4162,6 +4162,13 @@ execall@^1.0.0:
   dependencies:
     clone-regexp "^1.0.0"
 
+executioner@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/executioner/-/executioner-2.0.1.tgz#add328e03bc45dd598f358fbb529fc0be0ec6fcd"
+  integrity sha1-rdMo4DvEXdWY81j7tSn8C+Dsb80=
+  dependencies:
+    mixly "^1.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -4592,18 +4599,6 @@ fn-name@~2.0.1:
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
-focus-trap-vue@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-1.1.1.tgz#d29d2de3c64457cc708657682a6670af73982355"
-  integrity sha512-N+M4d4uYymCogct417gUL7wWSMIW/oUcCicfg3eRdo+gz7jlQnIGwUwViFxPkKV7iyzpc81g6JeSxRWiYWU3eQ==
-
-focus-trap@^6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.4.0.tgz#e9951484fddf933d9b9b0e95b499f9420f6a54d6"
-  integrity sha512-RpH291GjfNhy1ek+Iwe00oCaqJN0sBaB+S/v7BpCIldf39IslPI7657nOZ6HwgoEHpjCmUJoAY+Mfgrm0rohvQ==
-  dependencies:
-    tabbable "^5.2.0"
-
 follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
@@ -4706,6 +4701,11 @@ fstream@^1.0.0, fstream@^1.0.12:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+fulcon@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fulcon/-/fulcon-1.0.2.tgz#8a4dfda4c73fcd9cc62a79d5045c392b45547320"
+  integrity sha1-ik39pMc/zZzGKnnVBFw5K0VUcyA=
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -5479,6 +5479,14 @@ inquirer@^6.2.2:
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
+
+install-peers-cli@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/install-peers-cli/-/install-peers-cli-2.2.0.tgz#f76f1ec8ac9fa7f920c05743e011554edad85f8d"
+  integrity sha512-scSNvF49HDOLNm2xLFwST23g/OvfsceiA087bcGBgZP/ZNCrvpSaCn5IrWNZ2XYmFFykXF/6J1Zgm+D/JgRgtA==
+  dependencies:
+    commander "^2.20.0"
+    executioner "^2.0.1"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -7330,6 +7338,13 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mixly@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mixly/-/mixly-1.0.0.tgz#9b5a2e1f63e6dfba0d30e6797ffae62ab1dc24ef"
+  integrity sha1-m1ouH2Pm37oNMOZ5f/rmKrHcJO8=
+  dependencies:
+    fulcon "^1.0.1"
 
 "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
@@ -10425,11 +10440,6 @@ synchronous-promise@^2.0.6:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.15.tgz#07ca1822b9de0001f5ff73595f3d08c4f720eb8e"
   integrity sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
-
-tabbable@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
-  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
 
 table@4.0.2:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4592,6 +4592,18 @@ fn-name@~2.0.1:
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
+focus-trap-vue@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-1.1.1.tgz#d29d2de3c64457cc708657682a6670af73982355"
+  integrity sha512-N+M4d4uYymCogct417gUL7wWSMIW/oUcCicfg3eRdo+gz7jlQnIGwUwViFxPkKV7iyzpc81g6JeSxRWiYWU3eQ==
+
+focus-trap@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.4.0.tgz#e9951484fddf933d9b9b0e95b499f9420f6a54d6"
+  integrity sha512-RpH291GjfNhy1ek+Iwe00oCaqJN0sBaB+S/v7BpCIldf39IslPI7657nOZ6HwgoEHpjCmUJoAY+Mfgrm0rohvQ==
+  dependencies:
+    tabbable "^5.2.0"
+
 follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
@@ -10413,6 +10425,11 @@ synchronous-promise@^2.0.6:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.15.tgz#07ca1822b9de0001f5ff73595f3d08c4f720eb8e"
   integrity sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
+
+tabbable@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
+  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
 
 table@4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This change prevents focus from leaving the ao-modal component when navigating with the tab key. The focus-trap-vue and focus-trap libraries are added as peer dependencies (the embedding application must provide them, rather than bundling them into Blaze builds).